### PR TITLE
fix: match skeleton layouts to real content structure

### DIFF
--- a/src/components/admin-notification-manager.tsx
+++ b/src/components/admin-notification-manager.tsx
@@ -11,7 +11,7 @@ import { Switch } from "./ui/switch";
 import { Badge } from "./ui/badge";
 import { toast } from "sonner";
 import { Trash2, Edit, Plus, Bell, X } from "lucide-react";
-import { SkeletonCard } from "./loading-skeleton";
+import { SkeletonCard, SkeletonWarm } from "./loading-skeleton";
 import {
   Dialog,
   DialogContent,
@@ -277,7 +277,13 @@ export function AdminNotificationManager() {
 
       <div className="grid gap-4">
         {isLoading ? (
-          <SkeletonCard count={3} />
+          <>
+            <div className="flex items-center justify-between mb-2">
+              <SkeletonWarm className="h-8 w-48" />
+              <SkeletonWarm className="h-9 w-36 rounded-md" />
+            </div>
+            <SkeletonCard count={3} />
+          </>
         ) : notifications.length === 0 ? (
           <Card>
             <CardContent className="flex flex-col items-center justify-center py-12">

--- a/src/components/improved-feedback-form.tsx
+++ b/src/components/improved-feedback-form.tsx
@@ -6,7 +6,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Progress } from "@/components/ui/progress";
-import { SkeletonCard } from "@/components/loading-skeleton";
+import { SkeletonWarm } from "@/components/loading-skeleton";
 import { Badge } from "@/components/ui/badge";
 import { 
   Code, 
@@ -224,7 +224,18 @@ export default function FeedbackForm({ onSubmit, onSuccess, initialData, onChang
     }
   };
 
-  if (loading) return <div className="flex items-center justify-center h-64"><SkeletonCard count={3} /></div>;
+  if (loading) return (
+    <div className="space-y-6 p-6">
+      <SkeletonWarm className="h-7 w-48" />
+      <SkeletonWarm className="h-4 w-72" />
+      <SkeletonWarm className="h-2 w-full rounded-full" />
+      <SkeletonWarm className="h-10 w-full rounded-lg" />
+      <div className="space-y-3">
+        <SkeletonWarm className="h-10 w-full rounded-lg" />
+        <SkeletonWarm className="h-48 w-full rounded-lg" />
+      </div>
+    </div>
+  );
   if (error) return <div className="text-center text-destructive p-4">Error loading user data</div>;
 
   if (isSubmitted) {

--- a/src/components/leave-requests-table.tsx
+++ b/src/components/leave-requests-table.tsx
@@ -10,7 +10,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { toast } from "react-toastify";
-import { SkeletonTable } from "@/components/loading-skeleton";
+import { SkeletonTable, SkeletonWarm } from "@/components/loading-skeleton";
 import {
   getAllLeaveRequests,
   updateLeaveRequestStatus,
@@ -232,7 +232,14 @@ export function LeaveRequestsTable({ cohort }: LeaveRequestsTableProps) {
       <Card>
         <CardContent className="pt-6">
           {isLoading ? (
-            <SkeletonTable rows={5} cols={5} />
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+                {Array.from({ length: 3 }, (_, i) => (
+                  <SkeletonWarm key={i} className="h-24 rounded-xl" />
+                ))}
+              </div>
+              <SkeletonTable rows={5} cols={7} />
+            </>
           ) : requests.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">No leave requests found</div>
           ) : (

--- a/src/components/linear-feedback-form.tsx
+++ b/src/components/linear-feedback-form.tsx
@@ -5,7 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Progress } from "@/components/ui/progress";
-import { SkeletonCard } from "@/components/loading-skeleton";
+import { SkeletonWarm } from "@/components/loading-skeleton";
 import { Badge } from "@/components/ui/badge";
 import { 
   Code, 
@@ -292,7 +292,18 @@ export default function FeedbackForm({ onSubmit, onSuccess, initialData, onChang
     return () => window.removeEventListener("keydown", handleEnterKey);
   }, [showSubmitConfirmation]);
 
-  if (loading) return <div className="flex items-center justify-center h-64"><SkeletonCard count={3} /></div>;
+  if (loading) return (
+    <div className="space-y-6 p-6">
+      <SkeletonWarm className="h-7 w-48" />
+      <SkeletonWarm className="h-4 w-72" />
+      <SkeletonWarm className="h-2 w-full rounded-full" />
+      <SkeletonWarm className="h-10 w-full rounded-lg" />
+      <div className="space-y-3">
+        <SkeletonWarm className="h-10 w-full rounded-lg" />
+        <SkeletonWarm className="h-48 w-full rounded-lg" />
+      </div>
+    </div>
+  );
   if (error) return <div className="text-center text-destructive p-4">Error loading user data</div>;
 
   if (isSubmitted) {

--- a/src/pages/user-reflection.tsx
+++ b/src/pages/user-reflection.tsx
@@ -2,15 +2,24 @@
 
 import { useUserData } from "@/UserDataContext";
 import ReflectionsDashboard from "@/components/reflections-dashboard";
-import { SkeletonCard } from "@/components/loading-skeleton";
+import { SkeletonWarm } from "@/components/loading-skeleton";
 
 export default function ReflectionsPage() {
   const { userData, loading, error, refetchUserData } = useUserData();
 
   if (loading) {
     return (
-      <div className="container mx-auto py-10">
-        <SkeletonCard count={3} />
+      <div className="container mx-auto py-10 space-y-6">
+        <SkeletonWarm className="h-10 w-48" />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div key={i} className="rounded-xl border bg-card p-6 space-y-3 paper-texture">
+              <SkeletonWarm className="h-5 w-2/5" />
+              <SkeletonWarm className="h-4 w-full" />
+              <SkeletonWarm className="h-4 w-3/4" />
+            </div>
+          ))}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
- leave-requests-table: 5-col -> 7-col table + add 3 summary stat card skeletons
- improved/linear-feedback-form: replace generic cards with form-shaped skeleton
- user-reflection: replace stacked cards with dashboard layout (title + 3-card grid)
- admin-notification-manager: add toolbar skeleton above notification cards