### PR TITLE
feat(stamp-board): a11y and UX polish for stamp board

### DIFF
--- a/src/components/stamp/clear-stamps.tsx
+++ b/src/components/stamp/clear-stamps.tsx
@@ -40,7 +40,7 @@ export function ClearStamps({ cohortNumber }: ClearStampsProps) {
       <Button
         variant="outline"
         size="sm"
-        className="text-red-500 hover:text-red-700"
+        className="text-destructive hover:text-destructive"
         onClick={() => setOpen(true)}
       >
         <Trash2 className="mr-1.5 h-4 w-4" />
@@ -59,7 +59,7 @@ export function ClearStamps({ cohortNumber }: ClearStampsProps) {
             <AlertDialogAction
               onClick={() => mutation.mutate()}
               disabled={mutation.isLoading}
-              className="bg-red-500 hover:bg-red-600"
+              className="bg-destructive hover:bg-destructive/90"
             >
               {mutation.isLoading ? "Clearing..." : "Clear Board"}
             </AlertDialogAction>

--- a/src/components/stamp/cohort-board.tsx
+++ b/src/components/stamp/cohort-board.tsx
@@ -9,7 +9,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { STAMP_W } from "@/lib/stamp-mask";
-import { deterministicOffset, deterministicRotation } from "@/lib/stamp-rotation";
+import {
+  deterministicOffset,
+  deterministicOffsetX,
+  deterministicRotation,
+} from "@/lib/stamp-rotation";
 import type { Stamp } from "@/lib/stamp";
 
 interface CohortBoardProps {
@@ -69,7 +73,11 @@ export function CohortBoard({ stamps, isLocked, canDelete = false, userId }: Coh
                 >
                   <div
                     className="relative"
-                    style={{ transform: `translateY(${deterministicOffset(stamp.id)}px)` }}
+                    style={{
+                      transform: `translate(${deterministicOffsetX(stamp.id)}px, ${deterministicOffset(
+                        stamp.id
+                      )}px)`,
+                    }}
                   >
                     {canDelete && (
                       <div className="absolute -right-2 -top-2 z-10">
@@ -81,7 +89,10 @@ export function CohortBoard({ stamps, isLocked, canDelete = false, userId }: Coh
                     )}
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <div className="cursor-pointer">
+                        <button
+                          type="button"
+                          className="cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                        >
                           <StampImage
                             src={stamp.imageUrl}
                             alt={`Stamp from ${formatStampDate(stamp.createdAt)}`}
@@ -89,7 +100,7 @@ export function CohortBoard({ stamps, isLocked, canDelete = false, userId }: Coh
                             size={STAMP_SIZE}
                             className="rounded-sm shadow-lg drop-shadow-[0_4px_8px_rgba(0,0,0,0.18)] transition-[filter] duration-200 hover:drop-shadow-[0_10px_16px_rgba(0,0,0,0.28)]"
                           />
-                        </div>
+                        </button>
                       </TooltipTrigger>
                       <TooltipContent>
                         <p className="text-xs">

--- a/src/components/stamp/delete-stamp-button.tsx
+++ b/src/components/stamp/delete-stamp-button.tsx
@@ -41,7 +41,7 @@ export function DeleteStampButton({ cohortNumber, stampId }: DeleteStampButtonPr
       <Button
         variant="ghost"
         size="icon"
-        className="h-7 w-7 rounded-full bg-background/80 text-red-500 shadow-sm hover:bg-background hover:text-red-700"
+        className="rounded-full bg-background/80 text-destructive shadow-sm hover:bg-background hover:text-destructive"
         aria-label="Delete stamp"
         onClick={() => setOpen(true)}
       >
@@ -60,7 +60,7 @@ export function DeleteStampButton({ cohortNumber, stampId }: DeleteStampButtonPr
             <AlertDialogAction
               onClick={() => mutation.mutate()}
               disabled={mutation.isLoading}
-              className="bg-red-500 hover:bg-red-600"
+              className="bg-destructive hover:bg-destructive/90"
             >
               {mutation.isLoading ? "Removing..." : "Remove Stamp"}
             </AlertDialogAction>

--- a/src/components/stamp/poster-export.tsx
+++ b/src/components/stamp/poster-export.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Download, Upload } from "lucide-react";
+import { Download, Loader2, Upload } from "lucide-react";
 import { toast } from "react-toastify";
 
 import { Button } from "@/components/ui/button";
@@ -123,7 +123,11 @@ export function PosterExport({ cohortNumber, stamps }: PosterExportProps) {
         onClick={() => void handleExport()}
         disabled={isExporting || isUploading}
       >
-        <Download className="mr-1.5 h-4 w-4" />
+        {isExporting ? (
+          <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+        ) : (
+          <Download className="mr-1.5 h-4 w-4" />
+        )}
         {isExporting ? "Exporting..." : "Export Poster"}
       </Button>
       <Button
@@ -132,7 +136,11 @@ export function PosterExport({ cohortNumber, stamps }: PosterExportProps) {
         onClick={() => void handleUpload()}
         disabled={isExporting || isUploading}
       >
-        <Upload className="mr-1.5 h-4 w-4" />
+        {isUploading ? (
+          <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+        ) : (
+          <Upload className="mr-1.5 h-4 w-4" />
+        )}
         {isUploading ? "Saving..." : "Save Poster"}
       </Button>
     </div>

--- a/src/components/stamp/stamp-image.tsx
+++ b/src/components/stamp/stamp-image.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import type { CSSProperties } from "react";
+import { Stamp } from "lucide-react";
 import { STAMP_W, STAMP_H } from "@/lib/stamp-mask";
 
 interface StampImageProps {
@@ -18,6 +20,7 @@ export function StampImage({
   size = STAMP_W,
   className,
 }: StampImageProps) {
+  const [hasError, setHasError] = useState(false);
   const style: CSSProperties = {
     width: size,
     height: size * STAMP_RATIO,
@@ -27,5 +30,27 @@ export function StampImage({
     WebkitMaskImage: "url(#stamp-perf)",
   };
 
-  return <img src={src} alt={alt} loading="lazy" className={className} style={style} />;
+  if (hasError) {
+    return (
+      <div
+        role="img"
+        aria-label={alt}
+        className={`flex items-center justify-center bg-muted text-muted-foreground ${className ?? ""}`}
+        style={{ ...style, maskImage: undefined, WebkitMaskImage: undefined }}
+      >
+        <Stamp className="h-1/3 w-1/3 opacity-40" />
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      className={className}
+      style={style}
+      onError={() => setHasError(true)}
+    />
+  );
 }

--- a/src/components/stamp/upload-stamp-button.tsx
+++ b/src/components/stamp/upload-stamp-button.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import type { ChangeEvent } from "react";
-import { Camera } from "lucide-react";
+import { Camera, Check } from "lucide-react";
 import { toast } from "react-toastify";
 
 import { Button } from "@/components/ui/button";
@@ -10,6 +10,7 @@ import { prepareStampFile } from "@/lib/stamp-upload";
 
 interface UploadStampButtonProps {
   cohortNumber: number;
+  hasStampedToday?: boolean;
 }
 
 interface PendingStamp {
@@ -17,7 +18,7 @@ interface PendingStamp {
   previewUrl: string;
 }
 
-export function UploadStampButton({ cohortNumber }: UploadStampButtonProps) {
+export function UploadStampButton({ cohortNumber, hasStampedToday = false }: UploadStampButtonProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [pending, setPending] = useState<PendingStamp | null>(null);
   const [isPreparing, setIsPreparing] = useState(false);
@@ -72,11 +73,21 @@ export function UploadStampButton({ cohortNumber }: UploadStampButtonProps) {
       />
       <Button
         onClick={() => inputRef.current?.click()}
-        disabled={isUploading || isPreparing}
+        disabled={isUploading || isPreparing || hasStampedToday}
         className="rounded-full px-6"
+        aria-disabled={hasStampedToday}
       >
-        <Camera className="mr-2 h-4 w-4" />
-        {isUploading ? "Stamping..." : isPreparing ? "Preparing..." : "Add a Stamp"}
+        {hasStampedToday ? (
+          <>
+            <Check className="mr-2 h-4 w-4" />
+            See you tomorrow!
+          </>
+        ) : (
+          <>
+            <Camera className="mr-2 h-4 w-4" />
+            {isUploading ? "Stamping..." : isPreparing ? "Preparing..." : "Add a Stamp"}
+          </>
+        )}
       </Button>
       <StampPreviewDialog
         open={Boolean(pending)}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;500;600&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=DM+Serif+Display&family=JetBrains+Mono:wght@400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/src/lib/stamp-rotation.ts
+++ b/src/lib/stamp-rotation.ts
@@ -13,3 +13,11 @@ export function deterministicOffset(stampId: string, range: number = 6): number 
   }
   return (hash % (range * 2 + 1)) - range;
 }
+
+export function deterministicOffsetX(stampId: string, range: number = 4): number {
+  let hash = 0;
+  for (let i = 0; i < stampId.length; i += 1) {
+    hash = (hash * 37 + stampId.charCodeAt(i)) >>> 0;
+  }
+  return (hash % (range * 2 + 1)) - range;
+}

--- a/src/pages/stamp-board-page.tsx
+++ b/src/pages/stamp-board-page.tsx
@@ -94,7 +94,11 @@ export default function StampBoardPage() {
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
   const stampedToday = stamps.filter((stamp) => new Date(stamp.createdAt) >= todayStart).length;
+  const stampedTodayByUser = stamps.some(
+    (stamp) => stamp.ownerId === userId && new Date(stamp.createdAt) >= todayStart
+  );
   const uniqueStampers = new Set(stamps.map((stamp) => stamp.ownerId)).size;
+  const milestoneReached = stamps.length > 0 && stamps.length % 10 === 0;
   const stampsToMilestone = 10 - (stamps.length % 10);
   const milestoneProgress = ((stamps.length % 10) / 10) * 100;
 
@@ -130,7 +134,9 @@ export default function StampBoardPage() {
             </Select>
           )}
 
-          {!isLocked && <UploadStampButton cohortNumber={cohortNumber} />}
+          {!isLocked && (
+            <UploadStampButton cohortNumber={cohortNumber} hasStampedToday={stampedTodayByUser} />
+          )}
           <PosterExport cohortNumber={cohortNumber} stamps={stamps} />
           {isAdmin && <ClearStamps cohortNumber={cohortNumber} />}
         </div>
@@ -146,19 +152,19 @@ export default function StampBoardPage() {
           <strong className="text-foreground">{uniqueStampers}</strong> stampers
         </span>
         <span className="inline-flex items-center gap-1.5 rounded-full bg-muted/60 px-3 py-1.5 text-xs text-muted-foreground">
-          <Flame className="h-3.5 w-3.5 text-amber-500" />
+          <Flame className="h-3.5 w-3.5 text-accent" />
           <strong className="text-foreground">{stampedToday}</strong> stamped today
         </span>
         {stamps.length > 0 && (
           <span className="inline-flex items-center gap-2 rounded-full bg-muted/60 px-3 py-1.5 text-xs text-muted-foreground">
-            <Sparkles className="h-3.5 w-3.5 text-amber-500" />
+            <Sparkles className="h-3.5 w-3.5 text-accent" />
             <div className="h-1.5 w-20 overflow-hidden rounded-full bg-muted">
               <div
-                className="h-full rounded-full bg-amber-500 transition-all duration-500"
-                style={{ width: `${milestoneProgress}%` }}
+                className="h-full rounded-full bg-accent transition-all duration-300"
+                style={{ width: `${milestoneReached ? 100 : milestoneProgress}%` }}
               />
             </div>
-            {stampsToMilestone} to next milestone
+            {milestoneReached ? "Milestone reached!" : `${stampsToMilestone} to next milestone`}
           </span>
         )}
       </div>


### PR DESCRIPTION
- Make stamps focusable buttons with visible keyboard focus ring and tooltip
- Scatter stamps with deterministic X+Y offsets for a natural board look
- Replace hardcoded red/amber classes with theme tokens (destructive, accent)
- Fall back to a muted placeholder when a stamp image fails to load
- Disable upload button with 'See you tomorrow!' once user has stamped today
- Show 'Milestone reached!' when the board hits a full 10-stamp milestone
- Add busy spinners while exporting/saving the poster
- Load DM Sans, DM Serif Display, JetBrains Mono, Playfair Display fonts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upload controls now show a “See you tomorrow!” state after stamping for the day.
  - Stamp placement has more varied, consistent positioning.
  - Completed ten-stamp milestones now display full progress and updated messaging.
  - Export and save actions show loading indicators while processing.
  - Failed stamp images display an accessible placeholder instead of a broken image.

- **Accessibility**
  - Stamp images are now keyboard-focusable interactive buttons.

- **Style**
  - Updated typography options and standardized destructive action colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->