### PR TITLE
feat: add fertilizer item and redesign the streak plant

### DIFF
--- a/src/application/services/fertilizerService.ts
+++ b/src/application/services/fertilizerService.ts
@@ -1,0 +1,22 @@
+import { api } from "../../infrastructure/api";
+import type { FertilizerActionResponse, FertilizerGrantPayload } from "../../domain/types";
+
+export const fertilizerService = {
+  async grant(userId: string, payload: FertilizerGrantPayload): Promise<void> {
+    await api.post<FertilizerActionResponse>(`/admin/users/${userId}/fertilizer`, payload);
+  },
+
+  async bulkGrant(userIds: string[], payload: FertilizerGrantPayload): Promise<void> {
+    await api.post(`/admin/fertilizer/bulk`, { userIds, ...payload });
+  },
+
+  async protect(userId: string, date: string): Promise<void> {
+    await api.post<FertilizerActionResponse>(`/users/${userId}/fertilizer/protect`, { date });
+  },
+
+  async feed(userId: string): Promise<void> {
+    await api.post<FertilizerActionResponse>(`/users/${userId}/fertilizer/feed`);
+  },
+};
+
+export default fertilizerService;

--- a/src/application/services/index.ts
+++ b/src/application/services/index.ts
@@ -4,6 +4,7 @@ export { reflectionService, default as reflectionServiceDefault } from "./reflec
 export { attendanceService, default as attendanceServiceDefault } from "./attendanceService";
 export { leaveService, default as leaveServiceDefault } from "./leaveService";
 export { badgeService, default as badgeServiceDefault } from "./badgeService";
+export { fertilizerService, default as fertilizerServiceDefault } from "./fertilizerService";
 export { boardService, default as boardServiceDefault } from "./boardService";
 export { stampService, default as stampServiceDefault } from "./stampService";
 export { notificationService, default as notificationServiceDefault } from "./notificationService";

--- a/src/components/admin-users-table.tsx
+++ b/src/components/admin-users-table.tsx
@@ -40,6 +40,7 @@ interface AdminUsersTableProps {
 import { BarometerVisual, reflectionZones } from "@/components/barometer-visual";
 import { BulkActionsBar } from "@/components/bulk-actions-bar";
 import { AwardBadgeBulkDialog } from "@/components/award-badge-bulk-dialog";
+import { AwardFertilizerBulkDialog } from "@/components/award-fertilizer-bulk-dialog";
 import { BulkAttendanceDialog } from "@/components/bulk-attendance-dialog";
 import { LoadingRow } from "@/components/loading-row";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -66,6 +67,7 @@ export function AdminUsersTable({ users, isLoading }: AdminUsersTableProps) {
   const [projectGroupFilter, setProjectGroupFilter] = useState<string>("all");
   const [selectedUserIds, setSelectedUserIds] = useState<Set<string>>(new Set());
   const [bulkBadgeOpen, setBulkBadgeOpen] = useState(false);
+  const [bulkFertilizerOpen, setBulkFertilizerOpen] = useState(false);
   const [bulkAttendanceOpen, setBulkAttendanceOpen] = useState(false);
   const [isBulkExporting, setIsBulkExporting] = useState(false);
   const [deleteUserId, setDeleteUserId] = useState<string | null>(null);
@@ -438,6 +440,7 @@ export function AdminUsersTable({ users, isLoading }: AdminUsersTableProps) {
         totalCount={filteredUsers.length}
         onClearSelection={() => setSelectedUserIds(new Set())}
         onBulkBadge={() => setBulkBadgeOpen(true)}
+        onBulkFertilizer={() => setBulkFertilizerOpen(true)}
         onBulkAttendance={() => setBulkAttendanceOpen(true)}
         onBulkExport={handleBulkExport}
         isExporting={isBulkExporting}
@@ -504,6 +507,13 @@ export function AdminUsersTable({ users, isLoading }: AdminUsersTableProps) {
       <AwardBadgeBulkDialog
         isOpen={bulkBadgeOpen}
         onClose={() => setBulkBadgeOpen(false)}
+        userIds={Array.from(selectedUserIds)}
+        onSuccess={() => setSelectedUserIds(new Set())}
+      />
+
+      <AwardFertilizerBulkDialog
+        isOpen={bulkFertilizerOpen}
+        onClose={() => setBulkFertilizerOpen(false)}
         userIds={Array.from(selectedUserIds)}
         onSuccess={() => setSelectedUserIds(new Set())}
       />

--- a/src/components/award-fertilizer-bulk-dialog.tsx
+++ b/src/components/award-fertilizer-bulk-dialog.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Sprout, Users } from "lucide-react";
+import { fertilizerService } from "@/lib/api";
+import { toast } from "sonner";
+
+interface AwardFertilizerBulkDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  userIds: string[];
+  onSuccess?: () => void;
+}
+
+export function AwardFertilizerBulkDialog({ isOpen, onClose, userIds, onSuccess }: AwardFertilizerBulkDialogProps) {
+  const [amount, setAmount] = useState(1);
+  const [note, setNote] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (amount <= 0) {
+      toast.error("Amount must be at least 1.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await fertilizerService.bulkGrant(userIds, { amount, note: note || undefined });
+      toast.success(`Granted fertilizer to ${userIds.length} learner${userIds.length !== 1 ? "s" : ""}`);
+    } catch (error) {
+      console.error("Bulk fertilizer grant failed:", error);
+      toast.error("Failed to grant fertilizer. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+
+    onSuccess?.();
+    onClose();
+    setAmount(1);
+    setNote("");
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sprout className="h-5 w-5" />
+            Bulk Grant Fertilizer
+          </DialogTitle>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Users className="h-4 w-4" />
+            Granting to <span className="font-semibold text-foreground">{userIds.length}</span> learner{userIds.length !== 1 ? "s" : ""}
+          </div>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="bulk-fertilizer-amount">Amount (each)</Label>
+            <Input
+              id="bulk-fertilizer-amount"
+              type="number"
+              min={1}
+              value={amount}
+              onChange={(e) => setAmount(Math.max(1, Number(e.target.value) || 1))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="bulk-fertilizer-note">Note (optional)</Label>
+            <Input
+              id="bulk-fertilizer-note"
+              placeholder="e.g., End of sprint bonus"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={isSubmitting || userIds.length === 0}>
+            {isSubmitting ? "Granting..." : `Grant to ${userIds.length} Learner${userIds.length !== 1 ? "s" : ""}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/award-fertilizer-button.tsx
+++ b/src/components/award-fertilizer-button.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogFooter } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Sprout } from "lucide-react";
+import { fertilizerService } from "@/lib/api";
+import { toast } from "sonner";
+
+interface AwardFertilizerButtonProps {
+  userId: string;
+  onFertilizerAwarded?: () => void;
+}
+
+export function AwardFertilizerButton({ userId, onFertilizerAwarded }: AwardFertilizerButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [amount, setAmount] = useState(1);
+  const [note, setNote] = useState("");
+
+  const handleAward = async () => {
+    if (amount <= 0) {
+      toast.error("Amount must be at least 1.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await fertilizerService.grant(userId, { amount, note: note || undefined });
+      toast.success(`Granted ${amount} fertilizer${amount !== 1 ? "s" : ""}!`);
+      setIsOpen(false);
+      setAmount(1);
+      setNote("");
+      onFertilizerAwarded?.();
+    } catch (error) {
+      console.error("Error granting fertilizer:", error);
+      toast.error("Failed to grant fertilizer. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" className="gap-2">
+          <Sprout className="h-4 w-4" /> Grant Fertilizer
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sprout className="h-5 w-5" /> Grant Fertilizer
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="fertilizer-amount">Amount</Label>
+            <Input
+              id="fertilizer-amount"
+              type="number"
+              min={1}
+              value={amount}
+              onChange={(e) => setAmount(Math.max(1, Number(e.target.value) || 1))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="fertilizer-note">Note (optional)</Label>
+            <Input
+              id="fertilizer-note"
+              placeholder="e.g., Great job this week!"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => setIsOpen(false)} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleAward} disabled={isSubmitting}>
+            {isSubmitting ? "Granting..." : "Grant Fertilizer"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/bulk-actions-bar.tsx
+++ b/src/components/bulk-actions-bar.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { Award, Calendar, Download, X, Users } from "lucide-react";
+import { Award, Calendar, Download, Sprout, X, Users } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { motion, AnimatePresence } from "framer-motion";
 
@@ -8,6 +8,7 @@ interface BulkActionsBarProps {
   totalCount: number;
   onClearSelection: () => void;
   onBulkBadge: () => void;
+  onBulkFertilizer: () => void;
   onBulkAttendance: () => void;
   onBulkExport: () => void;
   isExporting?: boolean;
@@ -18,6 +19,7 @@ export function BulkActionsBar({
   totalCount,
   onClearSelection,
   onBulkBadge,
+  onBulkFertilizer,
   onBulkAttendance,
   onBulkExport,
   isExporting,
@@ -59,6 +61,16 @@ export function BulkActionsBar({
             >
               <Award className="h-4 w-4" />
               Award Badge
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onBulkFertilizer}
+              className="gap-1.5"
+            >
+              <Sprout className="h-4 w-4" />
+              Grant Fertilizer
             </Button>
 
             <Button

--- a/src/components/fertilizer-inventory-button.tsx
+++ b/src/components/fertilizer-inventory-button.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { fertilizerService } from "@/lib/api";
+import { toast } from "sonner";
+import { Shield, Sparkles } from "lucide-react";
+
+interface FertilizerInventoryButtonProps {
+  userId: string;
+  balance: number;
+  eligibleProtectDate: string | null;
+  onUsed?: () => void;
+}
+
+export function FertilizerInventoryButton({ userId, balance, eligibleProtectDate, onUsed }: FertilizerInventoryButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (balance <= 0) return null;
+
+  const handleProtect = async () => {
+    if (!eligibleProtectDate) return;
+    setIsSubmitting(true);
+    try {
+      await fertilizerService.protect(userId, eligibleProtectDate);
+      toast.success(`Protected ${eligibleProtectDate} — your streak is safe!`);
+      setIsOpen(false);
+      onUsed?.();
+    } catch {
+      toast.error("Couldn't protect that day. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleFeed = async () => {
+    setIsSubmitting(true);
+    try {
+      await fertilizerService.feed(userId);
+      toast.success("Your plant feels nourished! ✨");
+      setIsOpen(false);
+      onUsed?.();
+    } catch {
+      toast.error("Couldn't feed your plant. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1.5 rounded-full">
+          🧪 {balance}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-72">
+        <div className="flex flex-col gap-2">
+          <p className="text-sm font-medium">Use a fertilizer</p>
+          <Button
+            variant="outline"
+            className="justify-start gap-2"
+            disabled={!eligibleProtectDate || isSubmitting}
+            onClick={handleProtect}
+          >
+            <Shield className="h-4 w-4" />
+            {eligibleProtectDate ? `Protect ${eligibleProtectDate}` : "No missed day to protect"}
+          </Button>
+          <Button
+            variant="outline"
+            className="justify-start gap-2"
+            disabled={isSubmitting}
+            onClick={handleFeed}
+          >
+            <Sparkles className="h-4 w-4" />
+            Feed your plant (+10 growth)
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/genmate-garden.tsx
+++ b/src/components/genmate-garden.tsx
@@ -55,6 +55,7 @@ export interface GardenMember {
   variant: ReturnType<typeof getPlantVariant>;
   displayStreak: number;
   tier: ReturnType<typeof getPlantTier>;
+  growthPoints?: number;
 }
 
 export interface GardenGroup {
@@ -214,7 +215,7 @@ export function GenmateGarden({ cohort }: GenmateGardenProps) {
 }
 
 export function PlantTile({ member }: { member: GardenMember }) {
-  const { user, streakData, variant, displayStreak, tier } = member;
+  const { user, streakData, variant, displayStreak, tier, growthPoints } = member;
   const fullName = `${user.first_name ?? ""} ${user.last_name ?? ""}`.trim() || "Unknown learner";
   const nextMilestone = streakMilestones.find((m) => m.days > displayStreak) ?? null;
   const daysToNext = nextMilestone ? nextMilestone.days - displayStreak : 0;
@@ -241,6 +242,7 @@ export function PlantTile({ member }: { member: GardenMember }) {
             tier={tier}
             active={streakData.hasCurrentStreak}
             variant={variant}
+            growthPoints={growthPoints}
             showParticles={false}
             className="h-16 w-14 flex-shrink-0"
           />
@@ -277,6 +279,7 @@ export function PlantTile({ member }: { member: GardenMember }) {
               tier={tier}
               active={streakData.hasCurrentStreak}
               variant={variant}
+              growthPoints={growthPoints}
               className="h-14 w-12 flex-shrink-0"
             />
             <div className="flex flex-col gap-0.5 text-sm">

--- a/src/components/learner-genmate-garden-widget.tsx
+++ b/src/components/learner-genmate-garden-widget.tsx
@@ -21,6 +21,7 @@ const MiniPlant = ({ member }: { member: ReturnType<typeof mapGenmateMembers>[nu
         tier={member.tier}
         active={member.streakData.hasCurrentStreak}
         variant={member.variant}
+        growthPoints={member.growthPoints}
         showParticles={false}
         className="h-8 w-7 flex-shrink-0"
       />

--- a/src/components/reflections-dashboard.tsx
+++ b/src/components/reflections-dashboard.tsx
@@ -12,7 +12,7 @@ import { useReflections, type Reflection } from "@/hooks/use-reflections";
 import { useStreakCalculation } from "@/hooks/use-streak-calculation";
 import { reflectionZones, calculateZoneStats, findDominantZone } from "./reflection-zones";
 import { StreakIcon, GrowthBar, ComfortZoneMessage } from "./streak-components";
-import { getMilestoneForStreak, getRandomComfortMessage, getRandomStreakQuote } from "@/lib/streak-milestones";
+import { getMilestoneForStreak, getRandomComfortMessage, getRandomStreakQuote, getNextTierProgress } from "@/lib/streak-milestones";
 import { getPlantVariant } from "@/lib/plant-variants";
 import { ReflectionsTable } from "./reflections-table";
 import FeedbackForm from "./linear-feedback-form";
@@ -20,8 +20,10 @@ import { ReflectionPreview } from "./reflection-preview";
 import { SubmissionStatusCard } from "./submission-status-card";
 import { AchievementsSection } from "./achievements-section";
 import LearnerGenmateGardenWidget from "./learner-genmate-garden-widget";
+import { FertilizerInventoryButton } from "./fertilizer-inventory-button";
 import { api } from "@/lib/api";
 import type { Badge } from "@/lib/types";
+import type { FertilizerLogEntry } from "@/domain/types";
 
 // Define the User interface
 interface User {
@@ -35,6 +37,9 @@ interface User {
   project_group: string;
   genmate_group: string;
   badges?: Badge[];
+  fertilizer_balance?: number;
+  growth_points?: number;
+  fertilizer_log?: FertilizerLogEntry[];
 }
 
 interface ReflectionsDashboardProps {
@@ -45,35 +50,45 @@ interface ReflectionsDashboardProps {
 
 export default function ReflectionsDashboard({ userId, initialReflections = [], onReflectionSubmit }: ReflectionsDashboardProps) {
   const { reflections, isLoading: isLoadingReflections, error: reflectionsError, addReflection, refetch } = useReflections(userId, initialReflections);
-  const streakData = useStreakCalculation(reflections);
 
   const [user, setUser] = useState<User | null>(null); // New state for user
   const [isLoadingUser, setIsLoadingUser] = useState(false); // New loading state for user
   const [userError, setUserError] = useState<string | null>(null); // New error state for user
 
+  const protectedDates = useMemo(() => {
+    const dates = (user?.fertilizer_log ?? [])
+      .filter((entry) => entry.kind === "protect" && entry.relatedDate)
+      .map((entry) => entry.relatedDate as string);
+    return new Set(dates);
+  }, [user?.fertilizer_log]);
+
+  const streakData = useStreakCalculation(reflections, protectedDates);
+  const tierProgress = useMemo(() => getNextTierProgress(streakData.currentStreak), [streakData.currentStreak]);
+  const oldTierProgress = useMemo(() => getNextTierProgress(streakData.oldStreak), [streakData.oldStreak]);
+
   const plantVariant = useMemo(() => {
     return user ? getPlantVariant(user._id) : undefined;
   }, [user]);
 
-  useEffect(() => {
-    refetch(); // Refetch reflections
-
-    const fetchUser = async () => { // New function to fetch user
-      if (!userId) return;
-      setIsLoadingUser(true);
-      setUserError(null);
-      try {
+  const fetchUser = useCallback(async () => {
+    if (!userId) return;
+    setIsLoadingUser(true);
+    setUserError(null);
+    try {
       const response = await api.get<{ data: User }>(`users/${userId}`);
       setUser(response.data.data);
-      } catch (err) {
-        console.error("Error fetching user data:", err);
-        setUserError("Failed to load user data");
-      } finally {
-        setIsLoadingUser(false);
-      }
-    };
-    fetchUser(); // Call new fetch user function
-  }, [userId, refetch]); // Depend on userId and refetch
+    } catch (err) {
+      console.error("Error fetching user data:", err);
+      setUserError("Failed to load user data");
+    } finally {
+      setIsLoadingUser(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    refetch(); // Refetch reflections
+    fetchUser();
+  }, [userId, refetch, fetchUser]); // Depend on userId and refetch
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [formData, setFormData] = useState<
@@ -245,7 +260,15 @@ export default function ReflectionsDashboard({ userId, initialReflections = [], 
                 >
                   Daily Reflections
                 </motion.h1>
-                <StreakIcon streakData={streakData} variant={plantVariant} />
+                <StreakIcon streakData={streakData} variant={plantVariant} growthPoints={user?.growth_points ?? 0} />
+                {user && (
+                  <FertilizerInventoryButton
+                    userId={user._id}
+                    balance={user.fertilizer_balance ?? 0}
+                    eligibleProtectDate={streakData.eligibleProtectDate}
+                    onUsed={fetchUser}
+                  />
+                )}
               </div>
               <motion.p 
                 className="text-lg text-muted-foreground max-w-xl leading-relaxed"
@@ -643,11 +666,26 @@ export default function ReflectionsDashboard({ userId, initialReflections = [], 
                   </motion.p>
                   <div className="space-y-2">
                     <div className="flex items-center gap-3">
-                      <GrowthBar value={streakData.currentStreak} max={20} />
+                      <GrowthBar value={tierProgress.current} max={tierProgress.max} />
                       <div className="flex items-center gap-1">
                         <span className="tabular-nums font-medium">{streakData.currentStreak} day streak</span>
+                        <span className="text-xs text-muted-foreground tabular-nums">
+                          {tierProgress.isMaxTier ? "· max tier 🌟" : `· ${tierProgress.current}/${tierProgress.max} to next tier`}
+                        </span>
                       </div>
                     </div>
+                    {user && (user.growth_points ?? 0) > 0 && (
+                      <div className="flex items-center gap-3">
+                        <GrowthBar
+                          variant="growth"
+                          value={(user.growth_points ?? 0) % 50 || 50}
+                          max={50}
+                        />
+                        <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+                          ✨ {user.growth_points} growth points
+                        </span>
+                      </div>
+                    )}
                     {streakData.currentStreak >= 5 && (
                       <motion.div 
                         initial={{ opacity: 0, height: 0 }} 
@@ -711,15 +749,15 @@ export default function ReflectionsDashboard({ userId, initialReflections = [], 
                 </div>
                 <div className="w-full md:w-1/3">
                   <div className="relative h-3 bg-muted rounded-full overflow-hidden">
-                    <div 
-                      className="absolute top-0 left-0 h-full bg-gradient-to-r from-amber-500 to-amber-400" 
-                      style={{ width: `${(streakData.oldStreak / 20) * 100}%` }} 
+                    <div
+                      className="absolute top-0 left-0 h-full bg-gradient-to-r from-amber-500 to-amber-400"
+                      style={{ width: `${oldTierProgress.isMaxTier ? 100 : (oldTierProgress.current / oldTierProgress.max) * 100}%` }}
                     />
                   </div>
                   <div className="flex justify-between mt-2 text-xs text-muted-foreground">
                     <span>0</span>
-                    <span>10</span>
-                    <span>20 days</span>
+                    <span>{Math.round(oldTierProgress.max / 2)}</span>
+                    <span>{oldTierProgress.max} days</span>
                   </div>
                 </div>
               </div>

--- a/src/components/streak-components.tsx
+++ b/src/components/streak-components.tsx
@@ -9,12 +9,14 @@ import {
   getRandomComfortMessage,
   getPlantTier,
   getPlantTierConfig,
+  getFlourishTier,
+  flourishAccentColors,
   type PlantTier,
 } from "@/lib/streak-milestones"
 
 import { Cat } from "lucide-react"
 import { fireConfetti } from "@/lib/confetti"
-import { getPotPath, type PlantVariantConfig } from "@/lib/plant-variants"
+import { getPotPath, getStemTilt, type PlantVariantConfig } from "@/lib/plant-variants"
 
 const tierTextColors: Record<PlantTier, string> = {
   0: "text-muted-foreground",
@@ -34,8 +36,13 @@ const tierSubtextColors: Record<PlantTier, string> = {
   5: "text-amber-500/80 dark:text-amber-300/70",
 }
 
-export const GrowthBar = ({ value, max = 100 }: { value: number; max?: number }) => {
-  const progress = (value / max) * 100
+const growthBarGradients = {
+  streak: "linear-gradient(90deg, #8B6F47, #52B788, #2D6A4F)",
+  growth: "linear-gradient(90deg, #F59E0B, #FBBF24, #FDE68A)",
+}
+
+export const GrowthBar = ({ value, max = 100, variant = "streak" }: { value: number; max?: number; variant?: "streak" | "growth" }) => {
+  const progress = max > 0 ? (value / max) * 100 : 0
   const controls = useAnimation()
 
   useEffect(() => {
@@ -50,7 +57,7 @@ export const GrowthBar = ({ value, max = 100 }: { value: number; max?: number })
       <motion.div
         className="absolute top-0 left-0 h-full rounded-full"
         style={{
-          background: "linear-gradient(90deg, #8B6F47, #52B788, #2D6A4F)",
+          background: growthBarGradients[variant],
         }}
         initial={{ width: 0 }}
         animate={controls}
@@ -247,12 +254,47 @@ const PetalBurst = ({ onDone }: { onDone: () => void }) => {
   )
 }
 
-export const SeedlingPlant = ({ tier = 0, active, className, variant, showParticles = true }: { tier?: PlantTier; active: boolean; className?: string; variant?: PlantVariantConfig; showParticles?: boolean }) => {
+const AuraGlow = ({
+  sizePct,
+  color,
+  blurPx,
+  opacity,
+  duration,
+  topPct = 38,
+}: {
+  sizePct: number
+  color: string
+  blurPx: number
+  opacity: number
+  duration: number
+  topPct?: number
+}) => (
+  <motion.div
+    className="absolute rounded-full pointer-events-none"
+    style={{
+      width: `${sizePct}%`,
+      height: `${sizePct}%`,
+      top: `${topPct}%`,
+      left: "50%",
+      transform: "translate(-50%, -50%)",
+      background: `radial-gradient(circle, ${color}45 0%, ${color}18 50%, transparent 72%)`,
+      filter: `blur(${blurPx}px)`,
+      mixBlendMode: "screen",
+    }}
+    animate={{ scale: [0.92, 1.08, 0.92], opacity: [opacity * 0.6, opacity, opacity * 0.6] }}
+    transition={{ duration, repeat: Infinity, ease: "easeInOut" }}
+  />
+)
+
+export const SeedlingPlant = ({ tier = 0, active, className, variant, showParticles = true, growthPoints = 0 }: { tier?: PlantTier; active: boolean; className?: string; variant?: PlantVariantConfig; showParticles?: boolean; growthPoints?: number }) => {
   const swayControls = useAnimation()
   const leafBounceControls = useAnimation()
   const prefersReducedMotion = useReducedMotion()
   const config = getPlantTierConfig(tier)
   const potPaths = variant ? getPotPath(variant.pot) : null
+  const stemTilt = variant ? getStemTilt(variant.stem) : 0
+  const flourishTier = getFlourishTier(growthPoints)
+  const flourishColor = flourishAccentColors[flourishTier]
 
   useEffect(() => {
     if (active && !prefersReducedMotion) {
@@ -332,183 +374,52 @@ export const SeedlingPlant = ({ tier = 0, active, className, variant, showPartic
 
   return (
     <div className={`relative ${className}`}>
-      {/* Glow effects — Sunlight Through Canopy */}
+      {/* Glow effects — one clean light source per tier instead of stacked multi-hue smudges */}
       {active && !prefersReducedMotion && config.growthGlow === "glow" && (
         <>
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 8}px`,
-              background: `radial-gradient(circle, ${config.glowColor}22 0%, ${config.glowColor}10 50%, transparent 70%)`,
-              filter: "blur(8px)",
-            }}
-            animate={{ scale: [0.92, 1.08, 0.92], opacity: [0.18, 0.38, 0.18] }}
-            transition={{ duration: 4.5, repeat: Infinity, ease: "easeInOut" }}
-          />
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 3}px`,
-              background: `radial-gradient(circle, ${config.leafColor}30 0%, ${config.glowColor}15 60%, transparent 80%)`,
-              filter: "blur(3px)",
-            }}
-            animate={{ scale: [0.94, 1.06, 0.94], opacity: [0.2, 0.45, 0.2] }}
-            transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
-          />
+          <AuraGlow sizePct={80 * config.glowScale} color={config.glowColor} blurPx={8} opacity={0.3} duration={4.5} />
+          <AuraGlow sizePct={40 * config.glowScale} color={config.glowColor} blurPx={3} opacity={0.4} duration={3} />
         </>
       )}
 
       {active && !prefersReducedMotion && config.growthGlow === "radiant" && (
         <>
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 12}px`,
-              background: `radial-gradient(circle, ${config.glowColor}28 0%, ${config.glowColor}12 50%, transparent 72%)`,
-              filter: "blur(12px)",
-            }}
-            animate={{ scale: [0.88, 1.14, 0.88], opacity: [0.25, 0.5, 0.25] }}
-            transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
-          />
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 5}px`,
-              background: `radial-gradient(circle, ${config.flowerColor}25 0%, ${config.glowColor}14 55%, transparent 78%)`,
-              filter: "blur(5px)",
-            }}
-            animate={{ scale: [0.92, 1.1, 0.92], opacity: [0.3, 0.55, 0.3] }}
-            transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
-          />
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 2}px`,
-              background: `radial-gradient(circle, ${config.leafColor}35 0%, ${config.glowColor}20 65%, transparent 85%)`,
-              filter: "blur(2px)",
-            }}
-            animate={{ scale: [0.95, 1.05, 0.95], opacity: [0.2, 0.4, 0.2] }}
-            transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
-          />
+          <AuraGlow sizePct={100 * config.glowScale} color={config.glowColor} blurPx={11} opacity={0.35} duration={4} />
+          <AuraGlow sizePct={50 * config.glowScale} color={config.glowColor} blurPx={4} opacity={0.5} duration={2.6} />
         </>
       )}
 
       {active && !prefersReducedMotion && config.growthGlow === "bloom" && (
         <>
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 16}px`,
-              background: `radial-gradient(circle, ${config.glowColor}35 0%, ${config.glowColor}15 45%, transparent 68%)`,
-              filter: "blur(18px)",
-            }}
-            animate={{ scale: [0.84, 1.2, 0.84], opacity: [0.3, 0.6, 0.3] }}
-            transition={{ duration: 3.5, repeat: Infinity, ease: "easeInOut" }}
-          />
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 7}px`,
-              background: `radial-gradient(circle, ${config.flowerColor}35 0%, ${config.glowColor}18 50%, transparent 75%)`,
-              filter: "blur(7px)",
-            }}
-            animate={{ scale: [0.88, 1.15, 0.88], opacity: [0.35, 0.65, 0.35] }}
-            transition={{ duration: 2.5, repeat: Infinity, ease: "easeInOut" }}
-          />
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 2.5}px`,
-              background: `radial-gradient(circle, ${config.flowerColor}50 0%, ${config.glowColor}25 60%, transparent 82%)`,
-              filter: "blur(2.5px)",
-            }}
-            animate={{ scale: [0.92, 1.1, 0.92], opacity: [0.4, 0.75, 0.4] }}
-            transition={{ duration: 1.8, repeat: Infinity, ease: "easeInOut" }}
-          />
-          <motion.div
-            className="absolute inset-0 rounded-full border"
-            style={{ borderColor: config.flowerColor + "45" }}
-            animate={{ scale: [0.84, 1.12, 0.84], opacity: [0.2, 0.6, 0.2] }}
-            transition={{ duration: 3.2, repeat: Infinity, ease: "easeInOut" }}
-          />
+          <AuraGlow sizePct={130 * config.glowScale} color={config.glowColor} blurPx={16} opacity={0.4} duration={3.5} />
+          <AuraGlow sizePct={60 * config.glowScale} color={config.flowerColor} blurPx={6} opacity={0.55} duration={2.2} />
         </>
       )}
 
       {active && !prefersReducedMotion && config.growthGlow === "aurora" && (
         <>
+          <AuraGlow sizePct={170 * config.glowScale} color={config.glowColor} blurPx={22} opacity={0.45} duration={5} />
+          <AuraGlow sizePct={75 * config.glowScale} color={config.flowerColor} blurPx={7} opacity={0.6} duration={2.4} />
+          {/* Signature high-tier accent: a single slow-rotating ring, not another stacked blur */}
           <motion.div
-            className="absolute rounded-full"
+            className="absolute rounded-full pointer-events-none"
             style={{
-              inset: `-${5 * config.glowScale * 22}px`,
-              background: `radial-gradient(circle, ${config.fruitColor}28 0%, ${config.glowColor}12 38%, transparent 62%)`,
-              filter: "blur(26px)",
+              width: "115%",
+              height: "115%",
+              top: "38%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              border: `1px solid ${config.fruitColor}55`,
+              mixBlendMode: "screen",
             }}
-            animate={{ scale: [0.8, 1.28, 0.8], opacity: [0.25, 0.6, 0.25] }}
-            transition={{ duration: 5, repeat: Infinity, ease: "easeInOut" }}
-          />
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 13}px`,
-              background: `radial-gradient(circle, ${config.fruitColor}40 0%, ${config.glowColor}20 45%, transparent 70%)`,
-              filter: "blur(14px)",
-            }}
-            animate={{ scale: [0.84, 1.22, 0.84], opacity: [0.4, 0.8, 0.4] }}
-            transition={{ duration: 3.5, repeat: Infinity, ease: "easeInOut" }}
-          />
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 5}px`,
-              background: `radial-gradient(circle, ${config.fruitColor}45 0%, ${config.flowerColor}22 50%, transparent 75%)`,
-              filter: "blur(5px)",
-            }}
-            animate={{ scale: [0.9, 1.14, 0.9], opacity: [0.5, 0.85, 0.5] }}
-            transition={{ duration: 2.2, repeat: Infinity, ease: "easeInOut" }}
-          />
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 8}px`,
-              background: `radial-gradient(circle, ${config.fruitColor}35 0%, ${config.glowColor}15 55%, transparent 78%)`,
-              filter: "blur(8px)",
-            }}
-            animate={{ scale: [0.88, 1.16, 0.88], opacity: [0.3, 0.65, 0.3] }}
-            transition={{ duration: 2.8, repeat: Infinity, ease: "easeInOut" }}
-          />
-          <motion.div
-            className="absolute rounded-full"
-            style={{
-              inset: `-${5 * config.glowScale * 2.5}px`,
-              background: `radial-gradient(circle, ${config.fruitColor}55 0%, ${config.flowerColor}30 60%, transparent 82%)`,
-              filter: "blur(3px)",
-            }}
-            animate={{ scale: [0.93, 1.1, 0.93], opacity: [0.5, 0.9, 0.5] }}
-            transition={{ duration: 1.8, repeat: Infinity, ease: "easeInOut" }}
-          />
-          <motion.div
-            className="absolute inset-0 rounded-full pointer-events-none"
-            style={{
-              background: `conic-gradient(from 0deg, ${config.fruitColor}18, ${config.glowColor}10, ${config.flowerColor}12, ${config.stemColor}10, ${config.fruitColor}18)`,
-              mixBlendMode: "soft-light",
-            }}
-            animate={{ rotate: [0, 360], opacity: [0.12, 0.32, 0.12] }}
+            animate={{ rotate: [0, 360], opacity: [0.25, 0.55, 0.25] }}
             transition={{ rotate: { duration: 10, repeat: Infinity, ease: "linear" }, opacity: { duration: 4, repeat: Infinity, ease: "easeInOut" } }}
           />
         </>
       )}
 
       {!active && !prefersReducedMotion && config.growthGlow !== "none" && (
-        <motion.div
-          className="absolute rounded-full"
-          style={{
-            inset: `-${5 * config.glowScale * 6}px`,
-            background: `radial-gradient(circle, ${"#a1a1aa"}15 0%, transparent 65%)`,
-            filter: "blur(6px)",
-          }}
-          animate={{ opacity: [0.05, 0.12, 0.05] }}
-          transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
-        />
+        <AuraGlow sizePct={60 * config.glowScale} color="#a1a1aa" blurPx={6} opacity={0.1} duration={4} />
       )}
 
       {/* Plant SVG */}
@@ -556,277 +467,140 @@ export const SeedlingPlant = ({ tier = 0, active, className, variant, showPartic
                   <circle cx="27" cy="44" r="0.5" fill={outlineColor} opacity={0.2} />
                 </>
               )}
+              {/* Growth-points flourish: pot-rim accent (bronze/silver/gold) */}
+              {active && flourishTier > 0 && (
+                <path
+                  d={potPaths?.rim ?? "M7 44 L33 44 L31 41 L9 41 Z"}
+                  fill="none"
+                  stroke={flourishColor}
+                  strokeWidth={1.2}
+                  strokeLinejoin="round"
+                  opacity={0.85}
+                />
+              )}
             </g>
 
-            {/* Tier 0: Dormant — seed in soil */}
-            {tier === 0 && (
-              <g>
-                <ellipse cx="20" cy="42" rx="2.5" ry="1.8" fill={stemColor} stroke={outlineColor} strokeWidth="1" />
-                <line x1="20" y1="42" x2="20" y2="41" stroke={outlineColor} strokeWidth="0.8" strokeLinecap="round" />
-              </g>
-            )}
-
-            {/* Tier 1: Sprout */}
-            {tier >= 1 && (
-              <g opacity={tier >= 1 ? 1 : 0}>
-                {/* Stem */}
-                <path
-                  d="M20 42 Q19 40 20.5 37 Q21 35 20 33"
-                  stroke={stemColor}
-                  strokeWidth="2.2"
-                  strokeLinecap="round"
-                  fill="none"
-                />
-                {/* Leaves */}
-                <path
-                  d="M20 36 Q16 34 16.5 32 Q18 33 20 36"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M20 36 Q24 34 23.5 32 Q22 33 20 36"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-              </g>
-            )}
-
-            {/* Tier 2: Seedling */}
-            {tier >= 2 && (
-              <g opacity={tier >= 2 ? 1 : 0}>
-                {/* Main stem */}
-                <path
-                  d="M20 42 L20 30"
-                  stroke={stemColor}
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                />
-                {/* Left leaf */}
-                <path
-                  d="M20 36 Q14 33 15 30 Q17 32 20 36"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                {/* Right leaf */}
-                <path
-                  d="M20 36 Q26 33 25 30 Q23 32 20 36"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                {/* Top tiny leaf */}
-                <path
-                  d="M20 31 Q17 28 18 26 Q19 28 20 31"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-              </g>
-            )}
-
-            {/* Tier 3: Growing */}
-            {tier >= 3 && (
-              <g opacity={tier >= 3 ? 1 : 0}>
-                {/* Main stem */}
-                <path
-                  d="M20 42 Q21 36 19.5 30 Q19 26 20 22"
-                  stroke={stemColor}
-                  strokeWidth="2.8"
-                  strokeLinecap="round"
-                  fill="none"
-                />
-                {/* Bottom leaves */}
-                <path
-                  d="M20.5 38 Q14 35 15 32 Q17 34 20.5 38"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M20.5 38 Q27 35 26 32 Q24 34 20.5 38"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                {/* Middle leaves */}
-                <path
-                  d="M19.5 30 Q13 27 14 24 Q16 26 19.5 30"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M19.5 30 Q26 27 25 24 Q23 26 19.5 30"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                {/* Bud */}
-                <ellipse cx="20" cy="21" rx="2.5" ry="3" fill={flowerColor} stroke={outlineColor} strokeWidth="1.2" />
-                <ellipse cx="20" cy="21" rx="1.2" ry="1.8" fill={config.glowColor} opacity={0.5} />
-              </g>
-            )}
-
-            {/* Tier 4: Blooming */}
-            {tier >= 4 && (
-              <g opacity={tier >= 4 ? 1 : 0}>
-                {/* Stem */}
-                <path
-                  d="M20 42 Q21.5 36 20 30 Q19 26 20 20"
-                  stroke={stemColor}
-                  strokeWidth="3"
-                  strokeLinecap="round"
-                  fill="none"
-                />
-                {/* Bottom leaves */}
-                <path
-                  d="M20.5 38 Q13 35 14 31 Q17 33 20.5 38"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M20.5 38 Q28 35 27 31 Q24 33 20.5 38"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                {/* Middle leaves */}
-                <path
-                  d="M20 30 Q12 27 13 23 Q16 25 20 30"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M20 30 Q28 27 27 23 Q24 25 20 30"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                {/* Upper leaves */}
-                <path
-                  d="M20 24 Q14 22 15 19 Q17 21 20 24"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M20 24 Q26 22 25 19 Q23 21 20 24"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                {/* Flower */}
-                <g transform="translate(20, 17)">
-                  {/* Petals */}
-                  <path d="M0 -6 C-3 -10 -3 -4 0 -2 C3 -4 3 -10 0 -6" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                  <path d="M-6 0 C-10 -3 -4 -3 -2 0 C-4 3 -10 3 -6 0" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                  <path d="M6 0 C10 -3 4 -3 2 0 C4 3 10 3 6 0" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                  <path d="M0 6 C-3 10 -3 4 0 2 C3 4 3 10 0 6" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                  {/* Flower center */}
-                  <circle cx="0" cy="0" r="1.5" fill={config.glowColor} stroke={outlineColor} strokeWidth="0.8" />
+            {/* Plant, tilted per-user via variant.stem */}
+            <g transform={`rotate(${stemTilt} 20 44)`}>
+              {/* Tier 0: Dormant — plump seed in soil */}
+              {tier === 0 && (
+                <g>
+                  <ellipse cx="20" cy="42" rx="3" ry="2.2" fill={stemColor} stroke={outlineColor} strokeWidth="1" />
+                  <line x1="20" y1="42" x2="20" y2="40.5" stroke={outlineColor} strokeWidth="0.8" strokeLinecap="round" />
                 </g>
-              </g>
-            )}
+              )}
 
-            {/* Tier 5: Fruitful */}
-            {tier >= 5 && (
-              <g opacity={tier >= 5 ? 1 : 0}>
-                {/* Stem */}
-                <path
-                  d="M20 42 Q22 35 20 28 Q19 24 20 18"
-                  stroke={stemColor}
-                  strokeWidth="3.2"
-                  strokeLinecap="round"
-                  fill="none"
-                />
-                {/* Bottom leaves */}
-                <path
-                  d="M21 38 Q13 34 14 30 Q17 33 21 38"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M21 38 Q29 34 28 30 Q25 33 21 38"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                {/* Middle leaves */}
-                <path
-                  d="M20 28 Q11 25 12 21 Q15 23 20 28"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M20 28 Q29 25 28 21 Q25 23 20 28"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                {/* Upper leaves */}
-                <path
-                  d="M20 22 Q14 19 15 16 Q17 18 20 22"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M20 22 Q26 19 25 16 Q23 18 20 22"
-                  fill={leafColor}
-                  stroke={outlineColor}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                {/* Flower */}
-                <g transform="translate(20, 15)">
-                  <path d="M0 -5 C-2.5 -8 -2.5 -3 0 -1.5 C2.5 -3 2.5 -8 0 -5" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                  <path d="M-5 0 C-8 -2.5 -3 -2.5 -1.5 0 C-3 2.5 -8 2.5 -5 0" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                  <path d="M5 0 C8 -2.5 3 -2.5 1.5 0 C3 2.5 8 2.5 5 0" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                  <path d="M0 5 C-2.5 8 -2.5 3 0 1.5 C2.5 3 2.5 8 0 5" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                  <circle cx="0" cy="0" r="1.5" fill={config.glowColor} stroke={outlineColor} strokeWidth="0.8" />
+              {/* Tier 1: single curled sprout */}
+              {tier >= 1 && (
+                <g opacity={tier >= 1 ? 1 : 0}>
+                  <path
+                    d="M20 42 C18.5 39 18 36.5 20 34 C21 32.7 21.3 32 20.5 31"
+                    stroke={stemColor}
+                    strokeWidth="2.8"
+                    strokeLinecap="round"
+                    fill="none"
+                  />
+                  <ellipse cx="18.5" cy="31.5" rx="3.4" ry="2.2" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-35 18.5 31.5)" />
                 </g>
-                {/* Fruit */}
-                <g transform="translate(15, 33)">
-                  <circle cx="0" cy="0" r="3.5" fill={fruitColor} stroke={outlineColor} strokeWidth="1.2" />
-                  <path d="M0 -3.5 Q1 -4 2 -3.5" stroke={outlineColor} strokeWidth="0.8" fill="none" />
-                  {/* Shine */}
-                  <circle cx="-1" cy="-1" r="1" fill="white" opacity={0.4} />
+              )}
+
+              {/* Tier 2: twin round leaf pair + tiny topknot */}
+              {tier >= 2 && (
+                <g opacity={tier >= 2 ? 1 : 0}>
+                  <path d="M20 42 L20 29" stroke={stemColor} strokeWidth="3" strokeLinecap="round" />
+                  <ellipse cx="15" cy="33" rx="3.6" ry="2.4" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-30 15 33)" />
+                  <ellipse cx="25" cy="33" rx="3.6" ry="2.4" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(30 25 33)" />
+                  <circle cx="20" cy="28" r="2" fill={leafColor} stroke={outlineColor} strokeWidth="1.2" />
                 </g>
-                {/* Second fruit */}
-                <g transform="translate(26, 26)">
-                  <circle cx="0" cy="0" r="2.8" fill={fruitColor} stroke={outlineColor} strokeWidth="1" />
-                  <path d="M0 -2.8 Q0.8 -3.2 1.5 -2.8" stroke={outlineColor} strokeWidth="0.8" fill="none" />
-                  <circle cx="-0.8" cy="-0.8" r="0.8" fill="white" opacity={0.35} />
+              )}
+
+              {/* Tier 3: fuller canopy + closed bud */}
+              {tier >= 3 && (
+                <g opacity={tier >= 3 ? 1 : 0}>
+                  <path d="M20 42 Q21 36 19.5 30 Q19 26 20 22" stroke={stemColor} strokeWidth="3.2" strokeLinecap="round" fill="none" />
+                  <ellipse cx="14.5" cy="35" rx="4" ry="2.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-30 14.5 35)" />
+                  <ellipse cx="25.5" cy="35" rx="4" ry="2.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(30 25.5 35)" />
+                  <ellipse cx="13" cy="27" rx="3.6" ry="2.4" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-35 13 27)" />
+                  <ellipse cx="27" cy="27" rx="3.6" ry="2.4" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(35 27 27)" />
+                  {/* Closed bud — same overlapping-petal motif as the tier 4/5 bloom, drawn tight and unopened */}
+                  <ellipse cx="17.6" cy="23.5" rx="2.2" ry="1.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.2" transform="rotate(-30 17.6 23.5)" />
+                  <ellipse cx="22.4" cy="23.5" rx="2.2" ry="1.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.2" transform="rotate(30 22.4 23.5)" />
+                  <g transform="translate(20, 20)">
+                    <circle cx="0" cy="-1.5" r="2.2" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
+                    <circle cx="-1.8" cy="1" r="2.2" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
+                    <circle cx="1.8" cy="1" r="2.2" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
+                    <ellipse cx="-0.7" cy="-2" rx="0.7" ry="0.9" fill="white" opacity={0.4} />
+                  </g>
                 </g>
-              </g>
-            )}
+              )}
+
+              {/* Tier 4: open chunky bloom + denser canopy */}
+              {tier >= 4 && (
+                <g opacity={tier >= 4 ? 1 : 0}>
+                  <path d="M20 42 Q21.5 36 20 30 Q19 26 20 19" stroke={stemColor} strokeWidth="3.4" strokeLinecap="round" fill="none" />
+                  <ellipse cx="13.5" cy="37" rx="4.2" ry="2.7" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(-32 13.5 37)" />
+                  <ellipse cx="26.5" cy="37" rx="4.2" ry="2.7" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(32 26.5 37)" />
+                  <ellipse cx="12.5" cy="29" rx="3.8" ry="2.5" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(-38 12.5 29)" />
+                  <ellipse cx="27.5" cy="29" rx="3.8" ry="2.5" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(38 27.5 29)" />
+                  <ellipse cx="14.5" cy="23" rx="3.2" ry="2.1" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-40 14.5 23)" />
+                  <ellipse cx="25.5" cy="23" rx="3.2" ry="2.1" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(40 25.5 23)" />
+                  {/* Chunky open bloom: 5-petal circle cluster */}
+                  <g transform="translate(20, 16)">
+                    {[0, 72, 144, 216, 288].map((angle) => {
+                      const rad = (angle * Math.PI) / 180
+                      const px = Math.cos(rad) * 3.4
+                      const py = Math.sin(rad) * 3.4
+                      return <circle key={angle} cx={px} cy={py} r="2.6" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
+                    })}
+                    <circle cx="0" cy="0" r="2" fill={config.glowColor} stroke={outlineColor} strokeWidth="0.8" />
+                  </g>
+                </g>
+              )}
+
+              {/* Tier 5: bloom + two plump fruits + sparkle crown */}
+              {tier >= 5 && (
+                <g opacity={tier >= 5 ? 1 : 0}>
+                  <path d="M20 42 Q22 35 20 28 Q19 24 20 17" stroke={stemColor} strokeWidth="3.6" strokeLinecap="round" fill="none" />
+                  <ellipse cx="13" cy="37" rx="4.4" ry="2.8" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(-32 13 37)" />
+                  <ellipse cx="27" cy="37" rx="4.4" ry="2.8" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(32 27 37)" />
+                  <ellipse cx="11.5" cy="28" rx="4" ry="2.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(-38 11.5 28)" />
+                  <ellipse cx="28.5" cy="28" rx="4" ry="2.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(38 28.5 28)" />
+                  <ellipse cx="14" cy="22" rx="3.4" ry="2.2" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-40 14 22)" />
+                  <ellipse cx="26" cy="22" rx="3.4" ry="2.2" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(40 26 22)" />
+                  {/* Bloom */}
+                  <g transform="translate(20, 14)">
+                    {[0, 72, 144, 216, 288].map((angle) => {
+                      const rad = (angle * Math.PI) / 180
+                      const px = Math.cos(rad) * 3.6
+                      const py = Math.sin(rad) * 3.6
+                      return <circle key={angle} cx={px} cy={py} r="2.8" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
+                    })}
+                    <circle cx="0" cy="0" r="2.2" fill={config.glowColor} stroke={outlineColor} strokeWidth="0.8" />
+                  </g>
+                  {/* Sparkle crown — floats clear above the bloom instead of cutting through it */}
+                  <path
+                    d="M20 1.7 L20.7 3.8 L22.8 4.5 L20.7 5.2 L20 7.3 L19.3 5.2 L17.2 4.5 L19.3 3.8 Z"
+                    fill={config.glowColor}
+                    stroke={outlineColor}
+                    strokeWidth="0.6"
+                    opacity={0.95}
+                  />
+                  <circle cx="25" cy="6.5" r="0.9" fill={config.glowColor} opacity={0.8} />
+                  <circle cx="15" cy="7.5" r="0.6" fill={config.glowColor} opacity={0.7} />
+                  {/* Fruit — plump, with a small leafy calyx instead of a bare line */}
+                  <g transform="translate(14.5, 33)">
+                    <circle cx="0" cy="0" r="3.8" fill={fruitColor} stroke={outlineColor} strokeWidth="1.3" />
+                    <ellipse cx="0.3" cy="-3.6" rx="1.1" ry="0.7" fill={leafColor} stroke={outlineColor} strokeWidth="0.7" transform="rotate(20 0.3 -3.6)" />
+                    <circle cx="-1.1" cy="-1.1" r="1.1" fill="white" opacity={0.4} />
+                  </g>
+                  <g transform="translate(26.5, 26)">
+                    <circle cx="0" cy="0" r="3" fill={fruitColor} stroke={outlineColor} strokeWidth="1.1" />
+                    <ellipse cx="0.25" cy="-2.8" rx="0.9" ry="0.6" fill={leafColor} stroke={outlineColor} strokeWidth="0.6" transform="rotate(20 0.25 -2.8)" />
+                    <circle cx="-0.9" cy="-0.9" r="0.9" fill="white" opacity={0.35} />
+                  </g>
+                </g>
+              )}
+            </g>
           </svg>
         </motion.div>
       </motion.div>
@@ -928,7 +702,7 @@ export const SeedlingPlant = ({ tier = 0, active, className, variant, showPartic
   )
 }
 
-export const StreakIcon = ({ streakData, showMilestoneToast = true, variant }: { streakData: StreakData; showMilestoneToast?: boolean; variant?: PlantVariantConfig }) => {
+export const StreakIcon = ({ streakData, showMilestoneToast = true, variant, growthPoints = 0 }: { streakData: StreakData; showMilestoneToast?: boolean; variant?: PlantVariantConfig; growthPoints?: number }) => {
   const { currentStreak, oldStreak, hasCurrentStreak } = streakData
   const displayStreak = hasCurrentStreak ? currentStreak : oldStreak > 0 ? oldStreak : 0
   const tier = getPlantTier(displayStreak);
@@ -977,6 +751,7 @@ export const StreakIcon = ({ streakData, showMilestoneToast = true, variant }: {
             tier={tier}
             active={hasCurrentStreak}
             variant={variant}
+            growthPoints={growthPoints}
             className="w-10 h-12 flex-shrink-0"
           />
           <div className="flex flex-col leading-none">

--- a/src/domain/types/fertilizer.ts
+++ b/src/domain/types/fertilizer.ts
@@ -1,0 +1,26 @@
+export interface FertilizerLogEntry {
+  _id?: string;
+  kind: "grant" | "protect" | "feed";
+  amount: number;
+  relatedDate?: string;
+  note?: string;
+  grantedBy?: string;
+  createdAt: string;
+}
+
+export interface FertilizerState {
+  fertilizer_balance: number;
+  growth_points: number;
+  fertilizer_log: FertilizerLogEntry[];
+}
+
+export interface FertilizerGrantPayload {
+  amount: number;
+  note?: string;
+}
+
+export interface FertilizerActionResponse {
+  success: boolean;
+  message: string;
+  data: null;
+}

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -3,3 +3,4 @@ export * from "./user";
 export * from "./reflection";
 export * from "./attendance";
 export * from "./badge";
+export * from "./fertilizer";

--- a/src/domain/types/user.ts
+++ b/src/domain/types/user.ts
@@ -1,5 +1,6 @@
 import type { UserRole } from "./auth";
 import type { Badge } from "./badge";
+import type { FertilizerLogEntry } from "./fertilizer";
 
 export type { Badge };
 
@@ -22,6 +23,9 @@ export interface User {
   bio?: string;
   social_links?: SocialLinks;
   pinned_badge_ids?: string[];
+  fertilizer_balance?: number;
+  growth_points?: number;
+  fertilizer_log?: FertilizerLogEntry[];
 }
 
 export interface SocialLinks {
@@ -82,6 +86,8 @@ export interface GenmateGardenMember {
   cohort_number: number;
   genmate_group: string;
   reflection_dates: string[];
+  growth_points?: number;
+  protected_dates?: string[];
 }
 
 export interface GenmateGardenResponse {

--- a/src/hooks/use-reflections.ts
+++ b/src/hooks/use-reflections.ts
@@ -20,6 +20,7 @@ export interface StreakData {
   oldStreak: number;
   lastActiveDate: Date | null;
   hasCurrentStreak: boolean;
+  eligibleProtectDate: string | null;
 }
 
 export function useReflections(userId?: string, initialReflections: Reflection[] = []) {

--- a/src/hooks/use-streak-calculation.test.ts
+++ b/src/hooks/use-streak-calculation.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { calculateStreakData } from "./use-streak-calculation";
+import { isValidWorkday } from "@/utils/date-utils";
+import type { Reflection } from "./use-reflections";
+
+// Fixed "today" (a Wednesday) so the test doesn't flip behavior depending on
+// what real-world weekday it happens to run on.
+const FIXED_TODAY = new Date(2024, 0, 10, 12, 0, 0);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_TODAY);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function localDayString(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function makeReflection(day: string): Reflection {
+  return {
+    _id: `ref-${day}`,
+    user_id: "user-1",
+    date: `${day}T10:00:00.000Z`,
+    day,
+    createdAt: `${day}T10:00:00.000Z`,
+    reflection: {
+      barometer: "Comfort Zone",
+      tech_sessions: { happy: "hooks", improve: "state" },
+      non_tech_sessions: { happy: "sync", improve: "focus" },
+    },
+  } as Reflection;
+}
+
+// Walk back from FIXED_TODAY collecting `count` workdays (skipping weekends), oldest first.
+function lastNWorkdays(count: number): Date[] {
+  const days: Date[] = [];
+  const cursor = new Date(FIXED_TODAY);
+  cursor.setHours(0, 0, 0, 0);
+  while (days.length < count) {
+    if (isValidWorkday(cursor)) days.unshift(new Date(cursor));
+    cursor.setDate(cursor.getDate() - 1);
+  }
+  return days;
+}
+
+describe("calculateStreakData protected dates", () => {
+  it("breaks the streak on an unprotected gap", () => {
+    // last 5 workdays, but skip the 2nd-most-recent one (the gap)
+    const workdays = lastNWorkdays(5);
+    const gapDay = workdays[3];
+    const reflections = workdays
+      .filter((d) => d.getTime() !== gapDay.getTime())
+      .map((d) => makeReflection(localDayString(d)));
+
+    const streakData = calculateStreakData(reflections);
+
+    expect(streakData.eligibleProtectDate).toBe(localDayString(gapDay));
+    // streak should only cover the one workday after the gap, not bridge across it
+    const daysAfterGap = workdays.filter((d) => d.getTime() > gapDay.getTime()).length;
+    expect(streakData.currentStreak).toBe(daysAfterGap);
+  });
+
+  it("bridges the streak through a protected gap", () => {
+    const workdays = lastNWorkdays(5);
+    const gapDay = workdays[3];
+    const reflections = workdays
+      .filter((d) => d.getTime() !== gapDay.getTime())
+      .map((d) => makeReflection(localDayString(d)));
+
+    const protectedDates = new Set([localDayString(gapDay)]);
+    const streakData = calculateStreakData(reflections, protectedDates);
+
+    expect(streakData.currentStreak).toBe(workdays.length);
+    expect(streakData.hasCurrentStreak).toBe(true);
+  });
+});

--- a/src/hooks/use-streak-calculation.ts
+++ b/src/hooks/use-streak-calculation.ts
@@ -1,14 +1,23 @@
 import { useMemo } from "react";
 import type { Reflection, StreakData } from "./use-reflections";
-import { isHoliday, isWeekend, getPreviousWorkday } from "../utils/date-utils";
+import { isHoliday, isProtectedDate, isWeekend, getPreviousWorkday, toLocalDateKey } from "../utils/date-utils";
 
-export function calculateStreakData(reflections: Reflection[]): StreakData {
+// ponytail: 7-day lookback window is a placeholder product number, move to a config constant if it needs tuning
+const PROTECT_LOOKBACK_DAYS = 7;
+
+function withinLookback(date: Date, today: Date): boolean {
+  const diffDays = (today.getTime() - date.getTime()) / (1000 * 60 * 60 * 24);
+  return diffDays >= 0 && diffDays <= PROTECT_LOOKBACK_DAYS;
+}
+
+export function calculateStreakData(reflections: Reflection[], protectedDates: Set<string> = new Set()): StreakData {
   if (reflections.length === 0) {
     return {
       currentStreak: 0,
       oldStreak: 0,
       lastActiveDate: null,
       hasCurrentStreak: false,
+      eligibleProtectDate: null,
     };
   }
 
@@ -23,6 +32,7 @@ export function calculateStreakData(reflections: Reflection[]): StreakData {
   let lastActiveDate: Date | null = null;
   let hasCurrentStreak = false;
   let streakBroken = false;
+  let eligibleGapDate: Date | null = null;
 
   const hasTodayReflection = sortedDates.some((date) => {
     const d = new Date(date);
@@ -70,7 +80,7 @@ export function calculateStreakData(reflections: Reflection[]): StreakData {
           const d = new Date(date);
           d.setHours(0, 0, 0, 0);
           return d.getTime() === checkDate.getTime();
-        }) || isHoliday(checkDate);
+        }) || isHoliday(checkDate) || isProtectedDate(checkDate, protectedDates);
 
       if (hasReflectionOnDate) {
         currentStreak++;
@@ -78,6 +88,7 @@ export function calculateStreakData(reflections: Reflection[]): StreakData {
         checkDate = getPreviousWorkday(checkDate);
       } else {
         streakBroken = true;
+        eligibleGapDate = new Date(checkDate);
         break;
       }
     }
@@ -96,7 +107,7 @@ export function calculateStreakData(reflections: Reflection[]): StreakData {
             const d = new Date(date);
             d.setHours(0, 0, 0, 0);
             return d.getTime() === checkDate.getTime();
-          }) || isHoliday(checkDate);
+          }) || isHoliday(checkDate) || isProtectedDate(checkDate, protectedDates);
 
         if (hasReflectionOnDate) {
           oldStreak++;
@@ -107,6 +118,7 @@ export function calculateStreakData(reflections: Reflection[]): StreakData {
       }
     }
   } else {
+    eligibleGapDate = new Date(currentDate);
     let checkDate = getPreviousWorkday(today);
 
     while (true) {
@@ -120,7 +132,7 @@ export function calculateStreakData(reflections: Reflection[]): StreakData {
           const d = new Date(date);
           d.setHours(0, 0, 0, 0);
           return d.getTime() === checkDate.getTime();
-        }) || isHoliday(checkDate);
+        }) || isHoliday(checkDate) || isProtectedDate(checkDate, protectedDates);
 
       if (hasReflectionOnDate) {
         if (!lastActiveDate) lastActiveDate = new Date(checkDate);
@@ -132,11 +144,17 @@ export function calculateStreakData(reflections: Reflection[]): StreakData {
     }
   }
 
+  const eligibleProtectDate =
+    eligibleGapDate && !isWeekend(eligibleGapDate) && !isHoliday(eligibleGapDate) && withinLookback(eligibleGapDate, today)
+      ? toLocalDateKey(eligibleGapDate)
+      : null;
+
   return {
     currentStreak: hasCurrentStreak ? currentStreak : oldStreak,
     oldStreak,
     lastActiveDate,
     hasCurrentStreak: hasCurrentStreak || oldStreak > 0,
+    eligibleProtectDate,
   };
 }
 
@@ -144,6 +162,6 @@ export function getDisplayStreak(sd: StreakData): number {
   return sd.hasCurrentStreak ? sd.currentStreak : sd.oldStreak > 0 ? sd.oldStreak : 0;
 }
 
-export function useStreakCalculation(reflections: Reflection[]): StreakData {
-  return useMemo(() => calculateStreakData(reflections), [reflections]);
+export function useStreakCalculation(reflections: Reflection[], protectedDates: Set<string> = new Set()): StreakData {
+  return useMemo(() => calculateStreakData(reflections, protectedDates), [reflections, protectedDates]);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -8,6 +8,7 @@ export {
   attendanceService,
   leaveService,
   badgeService,
+  fertilizerService,
   boardService,
   stampService,
 } from "../application/services";

--- a/src/lib/genmate-garden.ts
+++ b/src/lib/genmate-garden.ts
@@ -10,7 +10,8 @@ export function mapGenmateMembers(members: GenmateGardenMember[]): GardenMember[
     const reflections = m.reflection_dates.map(
       (d) => ({ day: d }) as unknown as Reflection
     );
-    const streakData = calculateStreakData(reflections);
+    const protectedDates = new Set(m.protected_dates ?? []);
+    const streakData = calculateStreakData(reflections, protectedDates);
     const displayStreak = getDisplayStreak(streakData);
     return {
       user: {
@@ -25,6 +26,7 @@ export function mapGenmateMembers(members: GenmateGardenMember[]): GardenMember[
       variant: getPlantVariant(m._id),
       displayStreak,
       tier: getPlantTier(displayStreak),
+      growthPoints: m.growth_points ?? 0,
     };
   });
 }

--- a/src/lib/streak-milestones.ts
+++ b/src/lib/streak-milestones.ts
@@ -204,6 +204,33 @@ export function getPlantTier(streak: number): PlantTier {
   return 0
 }
 
+const TIER_THRESHOLDS: Record<PlantTier, number> = { 0: 0, 1: 1, 2: 10, 3: 20, 4: 30, 5: 50 }
+
+export type FlourishTier = 0 | 1 | 2 | 3
+
+const FLOURISH_THRESHOLDS: Record<FlourishTier, number> = { 0: 0, 1: 50, 2: 150, 3: 300 }
+export const flourishAccentColors: Record<FlourishTier, string> = {
+  0: "",
+  1: "#CD7F32", // bronze
+  2: "#C0C0C0", // silver
+  3: "#FFD700", // gold
+}
+
+export function getFlourishTier(growthPoints: number): FlourishTier {
+  if (growthPoints >= FLOURISH_THRESHOLDS[3]) return 3
+  if (growthPoints >= FLOURISH_THRESHOLDS[2]) return 2
+  if (growthPoints >= FLOURISH_THRESHOLDS[1]) return 1
+  return 0
+}
+
+export function getNextTierProgress(streak: number): { current: number; max: number; isMaxTier: boolean } {
+  const tier = getPlantTier(streak)
+  if (tier === 5) return { current: streak, max: streak, isMaxTier: true }
+  const next = TIER_THRESHOLDS[(tier + 1) as PlantTier]
+  const prev = TIER_THRESHOLDS[tier]
+  return { current: streak - prev, max: next - prev, isMaxTier: false }
+}
+
 export function getPlantTierConfig(tier: PlantTier): PlantTierConfig {
   return PLANT_TIER_CONFIGS[tier]
 }

--- a/src/pages/UserReflectionsPage.tsx
+++ b/src/pages/UserReflectionsPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -15,8 +15,10 @@ import { ReflectionsTable } from "@/components/reflections-table";
 import { useStreakCalculation } from "@/hooks/use-streak-calculation";
 import { StreakIcon } from "@/components/streak-components";
 import { AwardBadgeButton } from "@/components/award-badge-button";
+import { AwardFertilizerButton } from "@/components/award-fertilizer-button";
 import type { Badge } from "@/lib/types";
 import type { Reflection } from "@/hooks/use-reflections";
+import type { FertilizerLogEntry } from "@/domain/types";
 
 interface User {
   cohort_number: number;
@@ -27,6 +29,7 @@ interface User {
   role: string;
   _id: string;
   badges?: Badge[];
+  fertilizer_log?: FertilizerLogEntry[];
 }
 
 const StatCard = ({ icon: Icon, label, value }: { icon: LucideIcon; label: string; value: string | number | JSX.Element }) => (
@@ -92,7 +95,14 @@ export default function UserReflectionsPage() {
     }
   };
 
-  const streakData = useStreakCalculation(reflections);
+  const protectedDates = useMemo(() => {
+    const dates = (user?.fertilizer_log ?? [])
+      .filter((entry) => entry.kind === "protect" && entry.relatedDate)
+      .map((entry) => entry.relatedDate as string);
+    return new Set(dates);
+  }, [user?.fertilizer_log]);
+
+  const streakData = useStreakCalculation(reflections, protectedDates);
 
   if (isLoading) {
   return (
@@ -148,7 +158,12 @@ export default function UserReflectionsPage() {
           </Button>
           {userRole === "admin" && <UiBadge variant="default">Admin</UiBadge>}
         </div>
-        {id && <AwardBadgeButton userId={id} onBadgeAwarded={handleBadgeAwarded} />}
+        {id && (
+          <div className="flex items-center gap-2">
+            <AwardBadgeButton userId={id} onBadgeAwarded={handleBadgeAwarded} />
+            <AwardFertilizerButton userId={id} onFertilizerAwarded={handleBadgeAwarded} />
+          </div>
+        )}
       </motion.div>
 
       {user && (

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -146,6 +146,20 @@ export const isHoliday = (date: Date): boolean => {
   return HOLIDAYS.some((holiday) => holiday.getTime() === normalizedDate.getTime());
 };
 
+// Formats a date as a local YYYY-MM-DD key (not UTC — toISOString() would shift
+// the calendar day in non-UTC timezones like Thailand's UTC+7).
+export const toLocalDateKey = (date: Date): string => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+};
+
+// Helper function to check if a date has been protected by a fertilizer streak-freeze
+export const isProtectedDate = (date: Date, protectedDates: Set<string>): boolean => {
+  return protectedDates.has(toLocalDateKey(date));
+};
+
 // Function to check if a date is a valid workday (not weekend, not holiday)
 export const isValidWorkday = (date: Date): boolean => {
   return !isWeekend(date) && !isHoliday(date);


### PR DESCRIPTION
Fertilizer item (mirrors the badge admin-grant pattern):
- Admin can grant fertilizer to a student's inventory (single + bulk)
- Student spends it from a popover next to the streak icon on either protecting the single most recent missed workday (streak freeze) or feeding a persistent growth-points meter
- calculateStreakData now takes a protectedDates set, consulted alongside the existing isHoliday check, plus a new eligibleProtectDate on StreakData (7-day lookback) since there's no date picker - a fertilizer can only ever protect the one day currently breaking the streak
- Fixed a real timezone bug found while testing this: date-key generation was using toISOString() on a local-midnight date, which silently shifts the date backward a day in positive-UTC-offset zones like Thailand; switched to local Y-M-D formatting (isProtectedDate/toLocalDateKey)

GrowthBar fix:
- Was hardcoded to max={20} regardless of actual tier; now computes real days-to-next-tier via getNextTierProgress

Plant redesign (SeedlingPlant):
- Distinct chunky silhouette per tier instead of the same skeleton
  stretched taller: single curled sprout -> twin leaves+topknot ->
  closed bud -> open bloom -> bloom+fruit+sparkle
- Simplified the aura glow from 2-6 stacked multi-hue blurred layers per tier down to 1-2 layers off a single hue, blended with mix-blend-mode: screen and anchored over the canopy instead of the whole pot-to-crown box
- Fixed tier 3's bud (was a pink ellipse with a bright green glow circle stacked directly on top of it) into a proper closed bud using the same overlapping-petal-circle motif as the tier 4/5 open bloom
- Fixed tier 5's sparkle crown, which overlapped straight through the bloom; now floats clear above it with two companion twinkles, and both fruits get a small leafy calyx cap instead of a bare line
- Bronze/silver/gold pot-rim flourish tied to growth points

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can award fertilizer to individual learners or multiple selected learners, with optional notes.
  * Learners can use fertilizer to protect eligible missed dates or feed their plant.
  * Added fertilizer balances, activity tracking, and success/error feedback.
  * Added growth-point progression with tiered plant visuals, progress indicators, and flourish effects.
* **Enhancements**
  * Protected dates now preserve eligible streaks.
  * Streak progress dynamically reflects the learner’s current tier and growth.
* **Tests**
  * Added coverage for protected and unprotected streak gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->