### PR TITLE
Feat/expanded garden species

### DIFF
--- a/src/components/admin-users-table.tsx
+++ b/src/components/admin-users-table.tsx
@@ -438,6 +438,7 @@ export function AdminUsersTable({ users, isLoading }: AdminUsersTableProps) {
       <BulkActionsBar
         selectedCount={selectedUserIds.size}
         totalCount={filteredUsers.length}
+        onSelectAll={handleSelectAll}
         onClearSelection={() => setSelectedUserIds(new Set())}
         onBulkBadge={() => setBulkBadgeOpen(true)}
         onBulkFertilizer={() => setBulkFertilizerOpen(true)}

--- a/src/components/bulk-actions-bar.tsx
+++ b/src/components/bulk-actions-bar.tsx
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from "framer-motion";
 interface BulkActionsBarProps {
   selectedCount: number;
   totalCount: number;
+  onSelectAll: () => void;
   onClearSelection: () => void;
   onBulkBadge: () => void;
   onBulkFertilizer: () => void;
@@ -17,6 +18,7 @@ interface BulkActionsBarProps {
 export function BulkActionsBar({
   selectedCount,
   totalCount,
+  onSelectAll,
   onClearSelection,
   onBulkBadge,
   onBulkFertilizer,
@@ -45,7 +47,8 @@ export function BulkActionsBar({
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => {/* select all - handled by parent */}}
+              onClick={onSelectAll}
+              disabled={selectedCount === totalCount}
               className="text-xs h-7 px-2"
             >
               Select All

--- a/src/components/plant-palette-picker.tsx
+++ b/src/components/plant-palette-picker.tsx
@@ -1,20 +1,18 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { getAllPalettes, getPaletteUnlockTier } from "@/lib/plant-variants";
-import { getTierDayThreshold, type PlantTier } from "@/lib/streak-milestones";
+import { getAllPalettes } from "@/lib/plant-variants";
 import { updateUserPersonalDetails } from "@/application/services/userService";
 import { toast } from "sonner";
 import { Palette, Check } from "lucide-react";
 
 interface PlantPalettePickerProps {
   userId: string;
-  currentTier: PlantTier;
   selected?: string;
   onSaved?: () => void;
 }
 
-export function PlantPalettePicker({ userId, currentTier, selected, onSaved }: PlantPalettePickerProps) {
+export function PlantPalettePicker({ userId, selected, onSaved }: PlantPalettePickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const palettes = getAllPalettes();
@@ -45,32 +43,23 @@ export function PlantPalettePicker({ userId, currentTier, selected, onSaved }: P
         <div className="flex flex-col gap-2">
           <p className="text-sm font-medium">Choose your plant's color</p>
           <div className="grid grid-cols-5 gap-2">
-            {palettes.map((palette, index) => {
-              const unlockTier = getPaletteUnlockTier(index);
-              const unlocked = unlockTier <= currentTier;
+            {palettes.map((palette) => {
               const isSelected = selected === palette.name;
               return (
                 <button
                   key={palette.name}
                   type="button"
-                  disabled={!unlocked || isSaving}
+                  disabled={isSaving}
                   onClick={() => handlePick(palette.name)}
-                  title={
-                    unlocked
-                      ? palette.name
-                      : `${palette.name} — unlocks as your plant grows (day ${getTierDayThreshold(unlockTier)})`
-                  }
+                  title={palette.name}
                   className="relative flex h-10 w-10 items-center justify-center rounded-full border transition-transform enabled:hover:scale-110 disabled:opacity-30"
-                  style={{ backgroundColor: unlocked ? palette.leaf : undefined }}
+                  style={{ backgroundColor: palette.leaf }}
                 >
                   {isSelected && <Check className="h-4 w-4 text-white drop-shadow" />}
                 </button>
               );
             })}
           </div>
-          <p className="text-xs text-muted-foreground">
-            Locked colors bloom as your plant grows — keep your streak and fertilizer going!
-          </p>
         </div>
       </PopoverContent>
     </Popover>

--- a/src/components/reflections-dashboard.tsx
+++ b/src/components/reflections-dashboard.tsx
@@ -12,9 +12,8 @@ import { useReflections, type Reflection } from "@/hooks/use-reflections";
 import { useStreakCalculation } from "@/hooks/use-streak-calculation";
 import { reflectionZones, calculateZoneStats, findDominantZone } from "./reflection-zones";
 import { StreakIcon, GrowthBar, ComfortZoneMessage } from "./streak-components";
-import { getMilestoneForStreak, getRandomComfortMessage, getRandomStreakQuote, getNextTierProgress, getPlantTier, getEffectivePlantDays } from "@/lib/streak-milestones";
+import { getMilestoneForStreak, getRandomComfortMessage, getRandomStreakQuote, getNextTierProgress } from "@/lib/streak-milestones";
 import { getPlantVariant } from "@/lib/plant-variants";
-import { getDisplayStreak } from "@/hooks/use-streak-calculation";
 import { ReflectionsTable } from "./reflections-table";
 import FeedbackForm from "./linear-feedback-form";
 import { ReflectionPreview } from "./reflection-preview";
@@ -78,11 +77,6 @@ export default function ReflectionsDashboard({ userId, initialReflections = [], 
   const plantVariant = useMemo(() => {
     return user ? getPlantVariant(user._id, user.selected_palette) : undefined;
   }, [user]);
-
-  const currentTier = useMemo(
-    () => getPlantTier(getEffectivePlantDays(getDisplayStreak(streakData), user?.growth_points ?? 0)),
-    [streakData, user?.growth_points]
-  );
 
   const fetchUser = useCallback(async () => {
     if (!userId) return;
@@ -286,7 +280,6 @@ export default function ReflectionsDashboard({ userId, initialReflections = [], 
                 {user && (
                   <PlantPalettePicker
                     userId={user._id}
-                    currentTier={currentTier}
                     selected={user.selected_palette}
                     onSaved={fetchUser}
                   />

--- a/src/components/streak-components.tsx
+++ b/src/components/streak-components.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef, useEffect, useState, useCallback } from "react"
+import { useRef, useEffect, useState, useCallback, type ReactNode } from "react"
 import { motion, useAnimation, AnimatePresence, useReducedMotion } from "framer-motion"
 import type { StreakData } from "@/hooks/use-reflections"
 import {
@@ -17,24 +17,1054 @@ import {
 
 import { Cat } from "lucide-react"
 import { fireConfetti } from "@/lib/confetti"
-import { getPotPath, getStemTilt, type PlantVariantConfig } from "@/lib/plant-variants"
+import { getPotPath, getStemTilt, type PlantVariantConfig, type PlantSpecies } from "@/lib/plant-variants"
 
 const tierTextColors: Record<PlantTier, string> = {
   0: "text-muted-foreground",
-  1: "text-emerald-600 dark:text-emerald-400",
-  2: "text-green-600 dark:text-green-400",
-  3: "text-green-700 dark:text-green-300",
-  4: "text-emerald-700 dark:text-emerald-300",
-  5: "text-amber-600 dark:text-amber-300",
+  1: "text-emerald-500 dark:text-emerald-400",
+  2: "text-emerald-600 dark:text-emerald-400",
+  3: "text-green-600 dark:text-green-400",
+  4: "text-green-600 dark:text-green-300",
+  5: "text-green-700 dark:text-green-300",
+  6: "text-emerald-700 dark:text-emerald-300",
+  7: "text-pink-600 dark:text-pink-300",
+  8: "text-amber-600 dark:text-amber-300",
+  9: "text-amber-500 dark:text-amber-200",
 }
 
 const tierSubtextColors: Record<PlantTier, string> = {
   0: "text-muted-foreground/60",
   1: "text-emerald-500/80 dark:text-emerald-400/70",
-  2: "text-green-500/80 dark:text-green-400/70",
-  3: "text-green-600/80 dark:text-green-300/70",
-  4: "text-emerald-600/80 dark:text-emerald-300/70",
-  5: "text-amber-500/80 dark:text-amber-300/70",
+  2: "text-emerald-500/80 dark:text-emerald-400/70",
+  3: "text-green-500/80 dark:text-green-400/70",
+  4: "text-green-600/80 dark:text-green-400/70",
+  5: "text-green-600/80 dark:text-green-300/70",
+  6: "text-emerald-600/80 dark:text-emerald-300/70",
+  7: "text-pink-500/80 dark:text-pink-300/70",
+  8: "text-amber-500/80 dark:text-amber-300/70",
+  9: "text-amber-500/80 dark:text-amber-200/70",
+}
+
+/* ─── Procedural plant canopy ───
+   Each species gets its own growth topology (not a recolor of the same
+   shape): flower grows leaf pairs up a stem to a bloom, tree grows a trunk
+   into a leafy crown, cactus stacks spined paddle segments, succulent
+   radiates a rosette. Shapes are generated from `tier` by formula so all 10
+   tiers fall out of one function instead of ten hand-drawn blocks. */
+
+interface LeafSpec {
+  x: number
+  y: number
+  rx: number
+  ry: number
+  rot: number
+}
+
+function canopyTop(tier: PlantTier): number {
+  return Math.max(15, 42 - tier * 2.9)
+}
+
+function leafFan(tier: PlantTier): LeafSpec[] {
+  const pairs = Math.min(tier, 5)
+  const top = canopyTop(tier)
+  const leaves: LeafSpec[] = []
+  for (let i = 0; i < pairs; i++) {
+    const t = pairs === 1 ? 0.5 : i / (pairs - 1)
+    const y = 39 - t * (39 - (top + 5))
+    const spread = 4 + t * 2.4
+    const size = 3.6 + t * 0.9
+    const angle = 28 + t * 14
+    leaves.push({ x: 20 - spread, y, rx: size, ry: size * 0.62, rot: -angle })
+    leaves.push({ x: 20 + spread, y, rx: size, ry: size * 0.62, rot: angle })
+  }
+  return leaves
+}
+
+const StemPath = ({ tier, color, width }: { tier: PlantTier; color: string; width: number }) => {
+  if (tier === 0) return null
+  const top = canopyTop(tier)
+  return (
+    <path
+      d={`M20 42 Q21.2 ${((42 + top) / 2).toFixed(1)} 20 ${top}`}
+      stroke={color}
+      strokeWidth={width}
+      strokeLinecap="round"
+      fill="none"
+    />
+  )
+}
+
+const LeafGroup = ({ leaves, color, outline }: { leaves: LeafSpec[]; color: string; outline: string }) => (
+  <>
+    {leaves.map((l, i) => (
+      <ellipse
+        key={i}
+        cx={l.x}
+        cy={l.y}
+        rx={l.rx}
+        ry={l.ry}
+        fill={color}
+        stroke={outline}
+        strokeWidth={1.4}
+        transform={`rotate(${l.rot} ${l.x} ${l.y})`}
+      />
+    ))}
+  </>
+)
+
+const BloomCluster = ({
+  x,
+  y,
+  color,
+  glow,
+  outline,
+  scale = 1,
+}: {
+  x: number
+  y: number
+  color: string
+  glow: string
+  outline: string
+  scale?: number
+}) => (
+  <g transform={`translate(${x}, ${y})`}>
+    {[0, 72, 144, 216, 288].map((angle) => {
+      const rad = (angle * Math.PI) / 180
+      const px = Math.cos(rad) * 3.2 * scale
+      const py = Math.sin(rad) * 3.2 * scale
+      return <circle key={angle} cx={px} cy={py} r={2.4 * scale} fill={color} stroke={outline} strokeWidth="1" />
+    })}
+    <circle cx="0" cy="0" r={1.8 * scale} fill={glow} stroke={outline} strokeWidth="0.8" />
+  </g>
+)
+
+const FruitDot = ({
+  x,
+  y,
+  color,
+  leafColor,
+  outline,
+  r = 3.4,
+}: {
+  x: number
+  y: number
+  color: string
+  leafColor: string
+  outline: string
+  r?: number
+}) => (
+  <g transform={`translate(${x}, ${y})`}>
+    <circle cx="0" cy="0" r={r} fill={color} stroke={outline} strokeWidth="1.2" />
+    <ellipse
+      cx={r * 0.08}
+      cy={-r * 0.9}
+      rx={r * 0.28}
+      ry={r * 0.18}
+      fill={leafColor}
+      stroke={outline}
+      strokeWidth="0.6"
+      transform={`rotate(20 ${(r * 0.08).toFixed(2)} ${(-r * 0.9).toFixed(2)})`}
+    />
+    <circle cx={-r * 0.3} cy={-r * 0.3} r={r * 0.28} fill="white" opacity={0.4} />
+  </g>
+)
+
+interface CanopyColors {
+  stem: string
+  leaf: string
+  flower: string
+  fruit: string
+  glow: string
+  outline: string
+}
+
+const FlowerCanopy = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const leaves = leafFan(tier)
+  const top = canopyTop(tier)
+  const lowLeaf = leaves[0]
+  const highLeaf = leaves[leaves.length - 1]
+  return (
+    <>
+      <StemPath tier={tier} color={colors.stem} width={3} />
+      <LeafGroup leaves={leaves} color={colors.leaf} outline={colors.outline} />
+      {hasFlower && <BloomCluster x={20} y={top - 2} color={colors.flower} glow={colors.glow} outline={colors.outline} />}
+      {hasFruit && lowLeaf && <FruitDot x={lowLeaf.x} y={lowLeaf.y + 3} color={colors.fruit} leafColor={colors.leaf} outline={colors.outline} r={3.6} />}
+      {hasFruit && highLeaf && leaves.length > 2 && (
+        <FruitDot x={highLeaf.x} y={highLeaf.y + 3} color={colors.fruit} leafColor={colors.leaf} outline={colors.outline} r={2.8} />
+      )}
+    </>
+  )
+}
+
+const TreeCanopy = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const top = canopyTop(tier)
+  const crownR = 4 + tier * 0.9
+  const blobs = [
+    { x: 20, y: top, r: crownR },
+    { x: 20 - crownR * 0.65, y: top + crownR * 0.35, r: crownR * 0.75 },
+    { x: 20 + crownR * 0.65, y: top + crownR * 0.35, r: crownR * 0.75 },
+  ]
+  const accents = [
+    { x: -crownR * 0.3, y: -crownR * 0.2 },
+    { x: crownR * 0.35, y: crownR * 0.1 },
+    { x: 0, y: crownR * 0.45 },
+    { x: -crownR * 0.5, y: crownR * 0.5 },
+    { x: crownR * 0.5, y: -crownR * 0.4 },
+  ]
+  return (
+    <>
+      <StemPath tier={tier} color={colors.stem} width={4} />
+      {tier >= 2 &&
+        blobs.map((b, i) => (
+          <circle key={i} cx={b.x} cy={b.y} r={b.r} fill={colors.leaf} stroke={colors.outline} strokeWidth={1.5} />
+        ))}
+      {tier === 1 && <ellipse cx="20" cy={top} rx={4} ry={3} fill={colors.leaf} stroke={colors.outline} strokeWidth={1.4} />}
+      {hasFlower &&
+        accents.slice(0, 3).map((a, i) => (
+          <circle key={i} cx={20 + a.x} cy={top + a.y} r={1.4} fill={colors.flower} stroke={colors.outline} strokeWidth={0.7} />
+        ))}
+      {hasFruit &&
+        accents.map((a, i) => (
+          <circle key={`fruit-${i}`} cx={20 + a.x} cy={top + a.y} r={1.3} fill={colors.fruit} stroke={colors.outline} strokeWidth={0.7} />
+        ))}
+    </>
+  )
+}
+
+const CactusBody = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  if (tier === 0) return null
+  const segments = Math.min(1 + Math.floor((tier - 1) / 1.5), 6)
+  const segHeight = 4.2
+  const baseY = 42
+  const parts: ReactNode[] = []
+  for (let i = 0; i < segments; i++) {
+    const cy = baseY - segHeight * (i + 0.5) - i * 0.4
+    const width = 6.5 - i * 0.2
+    parts.push(
+      <rect
+        key={`seg-${i}`}
+        x={20 - width / 2}
+        y={cy - segHeight / 2}
+        width={width}
+        height={segHeight}
+        rx={width / 2}
+        fill={colors.stem}
+        stroke={colors.outline}
+        strokeWidth={1.5}
+      />
+    )
+    for (const s of [-1, 0, 1]) {
+      parts.push(
+        <line
+          key={`spine-${i}-${s}`}
+          x1={20 + s * width * 0.28}
+          y1={cy - segHeight * 0.3}
+          x2={20 + s * width * 0.28}
+          y2={cy + segHeight * 0.3}
+          stroke={colors.leaf}
+          strokeWidth="0.6"
+          strokeLinecap="round"
+        />
+      )
+    }
+  }
+  const top = baseY - segHeight * segments - (segments - 1) * 0.4
+  return (
+    <>
+      {parts}
+      {hasFlower && <BloomCluster x={20} y={top - 1} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.65} />}
+      {hasFruit && <FruitDot x={23} y={top + 2} color={colors.fruit} leafColor={colors.leaf} outline={colors.outline} r={2.2} />}
+    </>
+  )
+}
+
+const SucculentRosette = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  if (tier === 0) return null
+  const count = Math.min(4 + tier, 12)
+  const baseY = 40
+  const reach = 3.5 + Math.min(tier, 6) * 0.9
+  const spreadDeg = 150
+  const leaves: ReactNode[] = []
+  for (let i = 0; i < count; i++) {
+    const angle = count === 1 ? 0 : -spreadDeg / 2 + (spreadDeg / (count - 1)) * i
+    const rad = (angle * Math.PI) / 180
+    const px = 20 + Math.sin(rad) * reach
+    const py = baseY - Math.cos(rad) * reach * 0.8
+    leaves.push(
+      <ellipse
+        key={i}
+        cx={px}
+        cy={py}
+        rx={2.6}
+        ry={1.4}
+        fill={colors.leaf}
+        stroke={colors.outline}
+        strokeWidth="1.2"
+        transform={`rotate(${angle.toFixed(1)} ${px.toFixed(1)} ${py.toFixed(1)})`}
+      />
+    )
+  }
+  const spikeTop = 40 - Math.min(tier, 9) * 2.2
+  return (
+    <>
+      {leaves}
+      <circle cx="20" cy={baseY} r="2.2" fill={colors.stem} stroke={colors.outline} strokeWidth="1" />
+      {hasFlower && (
+        <>
+          <path d={`M20 ${baseY} L20 ${spikeTop}`} stroke={colors.stem} strokeWidth="1.6" strokeLinecap="round" />
+          <BloomCluster x={20} y={spikeTop - 1} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.6} />
+        </>
+      )}
+      {hasFruit && <FruitDot x={20} y={spikeTop + 3} color={colors.fruit} leafColor={colors.leaf} outline={colors.outline} r={1.8} />}
+    </>
+  )
+}
+
+const FernFronds = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const count = Math.min(2 + tier, 8)
+  const baseY = 42
+  const fronds: { tipX: number; tipY: number }[] = []
+  const parts: ReactNode[] = []
+  for (let i = 0; i < count; i++) {
+    const t = count === 1 ? 0.5 : i / (count - 1)
+    const angle = -65 + 130 * t
+    const rad = (angle * Math.PI) / 180
+    const length = 9 + Math.min(tier, 7) * 2.1
+    const tipX = 20 + Math.sin(rad) * length * 0.55
+    const tipY = baseY - Math.cos(rad) * length
+    fronds.push({ tipX, tipY })
+    const midX = 20 + Math.sin(rad) * length * 0.3
+    const midY = baseY - Math.cos(rad) * length * 0.55
+    parts.push(
+      <path
+        key={`spine-${i}`}
+        d={`M20 ${baseY} Q${midX.toFixed(1)} ${midY.toFixed(1)} ${tipX.toFixed(1)} ${tipY.toFixed(1)}`}
+        stroke={colors.stem}
+        strokeWidth={1.6}
+        fill="none"
+        strokeLinecap="round"
+      />
+    )
+    for (let j = 1; j <= 4; j++) {
+      const lt = j / 5
+      const lx = 20 + (tipX - 20) * lt
+      const ly = baseY + (tipY - baseY) * lt
+      const size = 1.7 * (1 - lt * 0.4)
+      parts.push(
+        <ellipse
+          key={`leaflet-${i}-${j}`}
+          cx={lx}
+          cy={ly}
+          rx={size}
+          ry={size * 0.55}
+          fill={colors.leaf}
+          stroke={colors.outline}
+          strokeWidth={0.8}
+          transform={`rotate(${angle} ${lx.toFixed(1)} ${ly.toFixed(1)})`}
+        />
+      )
+    }
+  }
+  const tallest = fronds.reduce((a, b) => (b.tipY < a.tipY ? b : a), fronds[0] ?? { tipX: 20, tipY: baseY })
+  return (
+    <>
+      {parts}
+      {hasFlower && <BloomCluster x={tallest.tipX} y={tallest.tipY} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.5} />}
+      {hasFruit && <FruitDot x={20} y={baseY - 2} color={colors.fruit} leafColor={colors.leaf} outline={colors.outline} r={1.8} />}
+    </>
+  )
+}
+
+function quadPoint(p0: { x: number; y: number }, p1: { x: number; y: number }, p2: { x: number; y: number }, t: number) {
+  const mt = 1 - t
+  return { x: mt * mt * p0.x + 2 * mt * t * p1.x + t * t * p2.x, y: mt * mt * p0.y + 2 * mt * t * p1.y + t * t * p2.y }
+}
+
+// Tendrils anchor to alternating sides of the rim (not one shared center point) and bow
+// outward before drooping, so they read as trailing over the pot edge instead of a bundle
+// of straight lines fanning from the middle. Leaflets follow the actual curve via
+// quadPoint rather than a straight lerp between endpoints, which drifted off-curve on wide bends.
+const VineDrape = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const count = Math.min(1 + Math.floor(tier / 2), 5)
+  const baseY = 41
+  const tips: { x: number; y: number }[] = []
+  const parts: ReactNode[] = []
+  for (let i = 0; i < count; i++) {
+    const side = i % 2 === 0 ? -1 : 1
+    const originX = 20 + side * (6 + Math.floor(i / 2) * 2)
+    const length = 4 + Math.min(tier, 8) * 0.65
+    const p0 = { x: originX, y: baseY }
+    const p1 = { x: originX + side * 4, y: baseY + length * 0.3 }
+    const p2 = { x: originX + side * 1.2, y: baseY + length }
+    tips.push(p2)
+    parts.push(
+      <path
+        key={`tendril-${i}`}
+        d={`M${p0.x} ${p0.y} Q${p1.x.toFixed(1)} ${p1.y.toFixed(1)} ${p2.x.toFixed(1)} ${p2.y.toFixed(1)}`}
+        stroke={colors.stem}
+        strokeWidth={1.3}
+        fill="none"
+        strokeLinecap="round"
+      />
+    )
+    for (let j = 1; j <= 4; j++) {
+      const lt = j / 5
+      const { x: lx, y: ly } = quadPoint(p0, p1, p2, lt)
+      const size = 1.5 + lt * 0.6
+      parts.push(
+        <ellipse
+          key={`leaflet-${i}-${j}`}
+          cx={lx}
+          cy={ly}
+          rx={size}
+          ry={size * 0.68}
+          fill={colors.leaf}
+          stroke={colors.outline}
+          strokeWidth={0.9}
+          transform={`rotate(${side * (25 + lt * 20)} ${lx.toFixed(1)} ${ly.toFixed(1)})`}
+        />
+      )
+    }
+  }
+  const longest = tips.reduce((a, b) => (b.y > a.y ? b : a), tips[0] ?? { x: 20, y: baseY })
+  return (
+    <>
+      {parts}
+      {hasFlower && <BloomCluster x={longest.x} y={longest.y} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.5} />}
+      {hasFruit && tips[1] && <FruitDot x={tips[1].x} y={tips[1].y} color={colors.fruit} leafColor={colors.leaf} outline={colors.outline} r={1.6} />}
+    </>
+  )
+}
+
+const BambooStalk = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  if (tier === 0) return null
+  const segments = Math.min(2 + Math.floor(tier / 1.2), 7)
+  const segHeight = 5
+  const baseY = 42
+  const width = 2.4
+  const parts: ReactNode[] = []
+  for (let i = 0; i < segments; i++) {
+    const cy = baseY - segHeight * (i + 0.5)
+    parts.push(
+      <rect
+        key={`joint-${i}`}
+        x={20 - width / 2}
+        y={cy - segHeight / 2}
+        width={width}
+        height={segHeight}
+        rx={width / 2}
+        fill={colors.stem}
+        stroke={colors.outline}
+        strokeWidth={1.3}
+      />
+    )
+    if (i > 0) {
+      const jointY = cy + segHeight / 2
+      const side = i % 2 === 0 ? 1 : -1
+      const leafX = 20 + side * 3.4
+      const leafY = jointY - 1.5
+      parts.push(
+        <line key={`band-${i}`} x1={20 - width / 2 - 0.3} y1={jointY} x2={20 + width / 2 + 0.3} y2={jointY} stroke={colors.outline} strokeWidth={0.7} />
+      )
+      parts.push(
+        <ellipse
+          key={`tuft-${i}`}
+          cx={leafX}
+          cy={leafY}
+          rx={2.6}
+          ry={0.8}
+          fill={colors.leaf}
+          stroke={colors.outline}
+          strokeWidth={0.7}
+          transform={`rotate(${side * 25} ${leafX} ${leafY})`}
+        />
+      )
+    }
+  }
+  const top = baseY - segHeight * segments
+  return (
+    <>
+      {parts}
+      {hasFlower && <BloomCluster x={20} y={top - 1} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.55} />}
+      {hasFruit && <FruitDot x={22.5} y={top + 2} color={colors.fruit} leafColor={colors.leaf} outline={colors.outline} r={1.8} />}
+    </>
+  )
+}
+
+const PalmCrown = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const top = canopyTop(tier)
+  const ringCount = Math.min(tier, 4)
+  const rings: ReactNode[] = []
+  for (let i = 1; i <= ringCount; i++) {
+    const ry = 42 - (42 - top) * (i / (ringCount + 1))
+    rings.push(<line key={`ring-${i}`} x1={18.2} y1={ry} x2={21.8} y2={ry} stroke={colors.outline} strokeWidth={0.6} opacity={0.5} />)
+  }
+  const frondCount = Math.min(3 + tier, 9)
+  const fronds: ReactNode[] = []
+  for (let i = 0; i < frondCount; i++) {
+    const t = frondCount === 1 ? 0.5 : i / (frondCount - 1)
+    const angle = -80 + 160 * t
+    const rad = (angle * Math.PI) / 180
+    const reach = 6 + Math.min(tier, 6) * 1.1
+    const tipX = 20 + Math.sin(rad) * reach
+    const tipY = top - Math.cos(rad) * reach * 0.45 + Math.abs(Math.sin(rad)) * reach * 0.3
+    const ctrlX = 20 + Math.sin(rad) * reach * 0.5
+    const ctrlY = top - reach * 0.3
+    fronds.push(
+      <path
+        key={`frond-${i}`}
+        d={`M20 ${top.toFixed(1)} Q${ctrlX.toFixed(1)} ${ctrlY.toFixed(1)} ${tipX.toFixed(1)} ${tipY.toFixed(1)}`}
+        stroke={colors.leaf}
+        strokeWidth={1.8}
+        fill="none"
+        strokeLinecap="round"
+      />
+    )
+  }
+  return (
+    <>
+      <StemPath tier={tier} color={colors.stem} width={2.3} />
+      {rings}
+      {fronds}
+      {hasFlower && <BloomCluster x={20} y={top + 1} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.5} />}
+      {hasFruit && <FruitDot x={23} y={top + 3} color={colors.fruit} leafColor={colors.leaf} outline={colors.outline} r={1.8} />}
+    </>
+  )
+}
+
+const MushroomCluster = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const count = Math.min(2 + Math.floor(tier / 1.4), 6)
+  const baseY = 42
+  const parts: ReactNode[] = []
+  let tallestCapY = baseY
+  for (let i = 0; i < count; i++) {
+    const t = count === 1 ? 0.5 : i / (count - 1)
+    const x = 20 + (t - 0.5) * 16
+    const h = 3 + Math.min(tier, 8) * 0.85 + (i % 2 === 0 ? 1 : 0)
+    const stalkTop = baseY - h
+    const capRx = 2.6 + Math.min(tier, 8) * 0.28 + (i % 2) * 0.4
+    const capRy = capRx * 0.55
+    const capFill = hasFlower ? colors.flower : colors.stem
+    tallestCapY = Math.min(tallestCapY, stalkTop)
+    parts.push(<rect key={`stalk-${i}`} x={x - 0.55} y={stalkTop} width={1.1} height={h} rx={0.5} fill={colors.leaf} stroke={colors.outline} strokeWidth={1} />)
+    parts.push(<ellipse key={`cap-${i}`} cx={x} cy={stalkTop} rx={capRx} ry={capRy} fill={capFill} stroke={colors.outline} strokeWidth={1.2} />)
+    if (hasFlower) {
+      parts.push(<circle key={`spot-${i}-a`} cx={x - capRx * 0.35} cy={stalkTop - capRy * 0.2} r={0.5} fill="white" opacity={0.75} />)
+      parts.push(<circle key={`spot-${i}-b`} cx={x + capRx * 0.3} cy={stalkTop + capRy * 0.1} r={0.4} fill="white" opacity={0.65} />)
+    }
+  }
+  return (
+    <>
+      {parts}
+      {hasFruit && (
+        <>
+          <rect x={28.5} y={baseY - 2} width={0.9} height={2} rx={0.4} fill={colors.leaf} stroke={colors.outline} strokeWidth={0.7} />
+          <ellipse cx={29} cy={baseY - 2} rx={1.6} ry={0.9} fill={colors.fruit} stroke={colors.outline} strokeWidth={0.8} />
+        </>
+      )}
+    </>
+  )
+}
+
+const PineTiers = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const trunkH = 2
+  const baseY = 42
+  const tiersN = Math.min(2 + tier, 8)
+  const layerH = 4.4
+  const parts: ReactNode[] = [
+    <rect key="trunk" x={19.3} y={baseY - trunkH} width={1.4} height={trunkH} fill={colors.stem} stroke={colors.outline} strokeWidth={1} />,
+  ]
+  const accents: { x: number; y: number }[] = []
+  let topY = baseY - trunkH
+  for (let i = 0; i < tiersN; i++) {
+    const width = Math.max(3, 11 - i * 0.95)
+    const layerTopY = topY - layerH
+    parts.push(
+      <polygon
+        key={`tier-${i}`}
+        points={`20,${layerTopY.toFixed(1)} ${(20 - width / 2).toFixed(1)},${topY.toFixed(1)} ${(20 + width / 2).toFixed(1)},${topY.toFixed(1)}`}
+        fill={colors.leaf}
+        stroke={colors.outline}
+        strokeWidth={1.2}
+        strokeLinejoin="round"
+      />
+    )
+    accents.push({ x: -width * 0.22, y: layerTopY + layerH * 0.55 })
+    accents.push({ x: width * 0.22, y: layerTopY + layerH * 0.3 })
+    topY = topY - layerH * 0.6
+  }
+  return (
+    <>
+      {parts}
+      {hasFlower &&
+        accents.slice(0, 3).map((a, i) => (
+          <circle key={`orn-${i}`} cx={20 + a.x} cy={a.y} r={1.1} fill={colors.flower} stroke={colors.outline} strokeWidth={0.6} />
+        ))}
+      {hasFruit &&
+        accents.map((a, i) => (
+          <ellipse key={`cone-${i}`} cx={20 + a.x} cy={a.y} rx={0.9} ry={1.6} fill={colors.fruit} stroke={colors.outline} strokeWidth={0.6} />
+        ))}
+    </>
+  )
+}
+
+const CloverMound = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const count = Math.min(3 + tier, 9)
+  const baseY = 41
+  const spread = 7 + Math.min(tier, 7) * 1.1
+  const parts: ReactNode[] = []
+  let tallest: { x: number; y: number } | null = null
+  for (let i = 0; i < count; i++) {
+    const t = count === 1 ? 0.5 : i / (count - 1)
+    const x = 20 + (t - 0.5) * 2 * spread
+    const riseFactor = 1 - Math.abs(t - 0.5) * 2
+    const y = baseY - (1.4 + riseFactor * 2.4)
+    parts.push(<line key={`stem-${i}`} x1={x} y1={baseY} x2={x} y2={y + 1} stroke={colors.stem} strokeWidth={0.9} strokeLinecap="round" />)
+    for (const angDeg of [-90, 30, 150]) {
+      const rad = (angDeg * Math.PI) / 180
+      const lx = x + Math.cos(rad) * 1.4
+      const ly = y + Math.sin(rad) * 1.4
+      parts.push(<circle key={`leaflet-${i}-${angDeg}`} cx={lx} cy={ly} r={1.3} fill={colors.leaf} stroke={colors.outline} strokeWidth={0.9} />)
+    }
+    if (!tallest || y < tallest.y) tallest = { x, y }
+  }
+  return (
+    <>
+      {parts}
+      {hasFlower && tallest && <BloomCluster x={tallest.x} y={tallest.y - 2} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.45} />}
+      {hasFruit && tallest && (
+        <circle cx={tallest.x + 1.6} cy={tallest.y - 1.6} r={1.1} fill={colors.fruit} stroke={colors.outline} strokeWidth={0.7} />
+      )}
+    </>
+  )
+}
+
+const OrchidStem = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const baseY = 42
+  const top = canopyTop(tier)
+  const driftX = Math.min(4 + tier * 0.6, 10)
+  const tipX = 20 + driftX
+  const ctrlX = 20 + driftX * 0.5
+  const ctrlY = (baseY + top) / 2
+  const bloomCount = hasFlower ? Math.min(Math.max(1, Math.floor((tier - 4) / 1.2)), 4) : 0
+  const blossoms: ReactNode[] = []
+  for (let j = 1; j <= bloomCount; j++) {
+    const lt = j / (bloomCount + 1)
+    const bx = 20 + (tipX - 20) * lt
+    const by = baseY + (top - baseY) * lt
+    blossoms.push(
+      <g key={`blossom-${j}`}>
+        <ellipse cx={bx - 1.6} cy={by} rx={1.8} ry={1.1} fill={colors.flower} stroke={colors.outline} strokeWidth={0.8} transform={`rotate(-25 ${(bx - 1.6).toFixed(1)} ${by.toFixed(1)})`} />
+        <ellipse cx={bx + 1.6} cy={by} rx={1.8} ry={1.1} fill={colors.flower} stroke={colors.outline} strokeWidth={0.8} transform={`rotate(25 ${(bx + 1.6).toFixed(1)} ${by.toFixed(1)})`} />
+        <circle cx={bx} cy={by} r={0.7} fill={colors.glow} stroke={colors.outline} strokeWidth={0.5} />
+      </g>
+    )
+  }
+  return (
+    <>
+      <path d={`M20 ${baseY} Q${ctrlX.toFixed(1)} ${ctrlY.toFixed(1)} ${tipX.toFixed(1)} ${top.toFixed(1)}`} stroke={colors.stem} strokeWidth={1.6} fill="none" strokeLinecap="round" />
+      <ellipse cx={17} cy={baseY - 1} rx={1.8} ry={4} fill={colors.leaf} stroke={colors.outline} strokeWidth={1} transform={`rotate(-12 17 ${baseY - 1})`} />
+      <ellipse cx={23} cy={baseY - 1} rx={1.8} ry={4} fill={colors.leaf} stroke={colors.outline} strokeWidth={1} transform={`rotate(12 23 ${baseY - 1})`} />
+      {blossoms}
+      {hasFruit && <ellipse cx={tipX} cy={top + 2} rx={0.9} ry={2.4} fill={colors.fruit} stroke={colors.outline} strokeWidth={0.8} transform={`rotate(15 ${tipX.toFixed(1)} ${(top + 2).toFixed(1)})`} />}
+    </>
+  )
+}
+
+const CoralFronds = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const count = Math.min(2 + Math.floor(tier / 1.3), 7)
+  const baseY = 42
+  const parts: ReactNode[] = []
+  for (let i = 0; i < count; i++) {
+    const t = count === 1 ? 0.5 : i / (count - 1)
+    const angle = -70 + 140 * t
+    const rad = (angle * Math.PI) / 180
+    const length = 7 + Math.min(tier, 7) * 1.6
+    const tipX = 20 + Math.sin(rad) * length * 0.6
+    const tipY = baseY - Math.cos(rad) * length
+    const perpRad = rad + Math.PI / 2
+    const wobble = (i % 2 === 0 ? 1 : -1) * 2.2
+    const ctrlX = 20 + Math.sin(rad) * length * 0.5 + Math.cos(perpRad) * wobble
+    const ctrlY = baseY - Math.cos(rad) * length * 0.5 + Math.sin(perpRad) * wobble
+    const bulbR = 1.5 + Math.min(tier, 8) * 0.15
+    parts.push(
+      <path
+        key={`tentacle-${i}`}
+        d={`M20 ${baseY} Q${ctrlX.toFixed(1)} ${ctrlY.toFixed(1)} ${tipX.toFixed(1)} ${tipY.toFixed(1)}`}
+        stroke={colors.stem}
+        strokeWidth={2.2}
+        fill="none"
+        strokeLinecap="round"
+      />
+    )
+    parts.push(<circle key={`bulb-${i}`} cx={tipX} cy={tipY} r={bulbR} fill={hasFlower ? colors.flower : colors.leaf} stroke={colors.outline} strokeWidth={1} />)
+  }
+  return (
+    <>
+      {parts}
+      {hasFruit && <FruitDot x={20} y={baseY - 3} color={colors.fruit} leafColor={colors.leaf} outline={colors.outline} r={1.6} />}
+    </>
+  )
+}
+
+const GrassTuft = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const count = Math.min(6 + tier, 14)
+  const baseY = 42
+  const blades: { x: number; y: number }[] = []
+  const parts: ReactNode[] = []
+  for (let i = 0; i < count; i++) {
+    const t = count === 1 ? 0.5 : i / (count - 1)
+    const angle = -60 + 120 * t
+    const rad = (angle * Math.PI) / 180
+    const length = 7 + Math.min(tier, 7) * 1.5
+    const tipX = 20 + Math.sin(rad) * length * 0.7
+    const tipY = baseY - Math.cos(rad) * length
+    const ctrlX = 20 + Math.sin(rad) * length * 0.3
+    const ctrlY = baseY - Math.cos(rad) * length * 0.75
+    blades.push({ x: tipX, y: tipY })
+    parts.push(
+      <path
+        key={`blade-${i}`}
+        d={`M20 ${baseY} Q${ctrlX.toFixed(1)} ${ctrlY.toFixed(1)} ${tipX.toFixed(1)} ${tipY.toFixed(1)}`}
+        stroke={colors.stem}
+        strokeWidth={0.9}
+        fill="none"
+        strokeLinecap="round"
+      />
+    )
+  }
+  const tallest = blades.reduce((a, b) => (b.y < a.y ? b : a), blades[0] ?? { x: 20, y: baseY })
+  return (
+    <>
+      {parts}
+      {hasFlower && <BloomCluster x={tallest.x} y={tallest.y} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.4} />}
+      {hasFruit && <FruitDot x={20} y={baseY - 3} color={colors.fruit} leafColor={colors.leaf} outline={colors.outline} r={1.4} />}
+    </>
+  )
+}
+
+const LotusPads = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const padCount = Math.min(2 + Math.floor(tier / 1.5), 6)
+  const baseY = 41.5
+  const parts: ReactNode[] = []
+  for (let i = 0; i < padCount; i++) {
+    const t = padCount === 1 ? 0.5 : i / (padCount - 1)
+    const x = 20 + (t - 0.5) * 14
+    const y = baseY - (i % 2 === 0 ? 0 : 0.6)
+    const padRx = 3.2 + Math.min(tier, 7) * 0.3
+    const padRy = padRx * 0.32
+    parts.push(<ellipse key={`pad-${i}`} cx={x} cy={y} rx={padRx} ry={padRy} fill={colors.leaf} stroke={colors.outline} strokeWidth={1} />)
+  }
+  const stemTopY = baseY - (6 + Math.min(tier, 9) * 1.4)
+  return (
+    <>
+      {parts}
+      {hasFlower && (
+        <>
+          <path d={`M20 ${baseY - 1} L20 ${stemTopY.toFixed(1)}`} stroke={colors.stem} strokeWidth={1.2} strokeLinecap="round" />
+          <BloomCluster x={20} y={stemTopY} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.9} />
+          <BloomCluster x={20} y={stemTopY} color={colors.glow} glow={colors.flower} outline={colors.outline} scale={0.5} />
+        </>
+      )}
+      {hasFruit && <FruitDot x={20} y={stemTopY + 2.5} color={colors.fruit} leafColor={colors.leaf} outline={colors.outline} r={1.6} />}
+    </>
+  )
+}
+
+const BonsaiPads = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const segs = Math.min(1 + Math.floor(tier / 2.2), 4)
+  const baseY = 42
+  const segLen = 3.4
+  const points: { x: number; y: number }[] = [{ x: 20, y: baseY }]
+  let cur = { x: 20, y: baseY }
+  for (let i = 0; i < segs; i++) {
+    const side = i % 2 === 0 ? 1 : -1
+    cur = { x: cur.x + side * 2, y: cur.y - segLen }
+    points.push(cur)
+  }
+  const trunkPath = points.map((p) => `${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(" L")
+  const padCount = Math.min(1 + Math.floor(tier / 2), 3)
+  const pads: { x: number; y: number }[] = []
+  const padParts: ReactNode[] = []
+  for (let i = 0; i < padCount; i++) {
+    const anchor = points[points.length - 1 - i] ?? cur
+    const side = i % 2 === 0 ? -1 : 1
+    const px = anchor.x + side * (3.5 + i * 0.5)
+    const py = anchor.y - 0.5
+    pads.push({ x: px, y: py })
+    padParts.push(<ellipse key={`pad-${i}`} cx={px} cy={py} rx={4 - i * 0.4} ry={1.2} fill={colors.leaf} stroke={colors.outline} strokeWidth={1.1} />)
+  }
+  return (
+    <>
+      <path d={`M${trunkPath}`} stroke={colors.stem} strokeWidth={2.2} fill="none" strokeLinecap="round" strokeLinejoin="round" />
+      {padParts}
+      {hasFlower &&
+        pads.slice(0, 2).map((p, i) => <circle key={`blossom-${i}`} cx={p.x} cy={p.y - 1} r={1} fill={colors.flower} stroke={colors.outline} strokeWidth={0.6} />)}
+      {hasFruit && pads[0] && <circle cx={pads[0].x - 1.5} cy={pads[0].y} r={1} fill={colors.fruit} stroke={colors.outline} strokeWidth={0.6} />}
+    </>
+  )
+}
+
+const FlytrapJaws = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const count = Math.min(2 + Math.floor(tier / 1.5), 6)
+  const baseY = 42
+  const parts: ReactNode[] = []
+  const traps: { x: number; y: number }[] = []
+  for (let i = 0; i < count; i++) {
+    const t = count === 1 ? 0.5 : i / (count - 1)
+    const angle = -60 + 120 * t
+    const rad = (angle * Math.PI) / 180
+    const stalkLen = 5 + Math.min(tier, 8) * 0.9
+    const tipX = 20 + Math.sin(rad) * stalkLen * 0.7
+    const tipY = baseY - Math.cos(rad) * stalkLen
+    traps.push({ x: tipX, y: tipY })
+    parts.push(
+      <path
+        key={`stalk-${i}`}
+        d={`M20 ${baseY} Q${(20 + Math.sin(rad) * stalkLen * 0.3).toFixed(1)} ${(baseY - Math.cos(rad) * stalkLen * 0.5).toFixed(1)} ${tipX.toFixed(1)} ${tipY.toFixed(1)}`}
+        stroke={colors.stem}
+        strokeWidth={1.3}
+        fill="none"
+        strokeLinecap="round"
+      />
+    )
+    for (const side of [-1, 1]) {
+      const lobeRot = angle + side * 22
+      const lobeRad = (lobeRot * Math.PI) / 180
+      const lobeCx = tipX + Math.sin(lobeRad) * 2.2
+      const lobeCy = tipY - Math.cos(lobeRad) * 2.2
+      parts.push(
+        <ellipse
+          key={`lobe-${i}-${side}`}
+          cx={lobeCx}
+          cy={lobeCy}
+          rx={3}
+          ry={1.6}
+          fill={colors.leaf}
+          stroke={colors.outline}
+          strokeWidth={1}
+          transform={`rotate(${lobeRot.toFixed(0)} ${lobeCx.toFixed(1)} ${lobeCy.toFixed(1)})`}
+        />
+      )
+    }
+  }
+  return (
+    <>
+      {parts}
+      {hasFlower && traps[0] && <circle cx={traps[0].x} cy={traps[0].y} r={0.9} fill={colors.flower} stroke={colors.outline} strokeWidth={0.5} />}
+      {hasFruit && traps[1] && <circle cx={traps[1].x} cy={traps[1].y} r={0.6} fill={colors.outline} opacity={0.8} />}
+    </>
+  )
+}
+
+const SunflowerStem = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  if (tier === 0) return null
+  const top = canopyTop(tier)
+  const parts: ReactNode[] = [<StemPath key="stem" tier={tier} color={colors.stem} width={3.2} />]
+  if (tier >= 2) parts.push(<ellipse key="leaf-l" cx={14.5} cy={38} rx={3.4} ry={2.2} fill={colors.leaf} stroke={colors.outline} strokeWidth={1.3} transform="rotate(-25 14.5 38)" />)
+  if (tier >= 4) parts.push(<ellipse key="leaf-r" cx={25.5} cy={32} rx={3.6} ry={2.3} fill={colors.leaf} stroke={colors.outline} strokeWidth={1.3} transform="rotate(25 25.5 32)" />)
+  if (hasFlower) {
+    const petals: ReactNode[] = []
+    for (let a = 0; a < 360; a += 30) {
+      const rad = (a * Math.PI) / 180
+      const px = 20 + Math.sin(rad) * 5.4
+      const py = top - Math.cos(rad) * 5.4
+      petals.push(<ellipse key={`petal-${a}`} cx={px} cy={py} rx={2.6} ry={1.1} fill={colors.flower} stroke={colors.outline} strokeWidth={0.8} transform={`rotate(${a} ${px.toFixed(1)} ${py.toFixed(1)})`} />)
+    }
+    parts.push(<g key="head">{petals}</g>)
+    parts.push(<circle key="disc" cx={20} cy={top} r={3.2} fill={colors.fruit} stroke={colors.outline} strokeWidth={1.1} />)
+    if (hasFruit) {
+      parts.push(
+        <g key="seeds">
+          {[-1.3, 0, 1.3].map((dx, i) => (
+            <circle key={i} cx={20 + dx} cy={top + (i % 2 === 0 ? -0.8 : 0.9)} r={0.4} fill={colors.outline} opacity={0.6} />
+          ))}
+        </g>
+      )
+    }
+  } else {
+    parts.push(<circle key="bud" cx={20} cy={top} r={1.8} fill={colors.leaf} stroke={colors.outline} strokeWidth={1} />)
+  }
+  return <>{parts}</>
+}
+
+const PomPomTopiary = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  if (tier === 0) return null
+  const top = canopyTop(tier)
+  const ballR = 3 + tier * 0.85
+  const accents = [
+    { x: -ballR * 0.4, y: -ballR * 0.3 }, { x: ballR * 0.35, y: ballR * 0.1 }, { x: 0, y: ballR * 0.4 },
+    { x: -ballR * 0.5, y: ballR * 0.35 }, { x: ballR * 0.45, y: -ballR * 0.35 },
+  ]
+  return (
+    <>
+      <StemPath tier={tier} color={colors.stem} width={2.4} />
+      <circle cx={20} cy={top} r={ballR} fill={colors.leaf} stroke={colors.outline} strokeWidth={1.6} />
+      {hasFlower && accents.slice(0, 3).map((a, i) => <circle key={`bloom-${i}`} cx={20 + a.x} cy={top + a.y} r={1.2} fill={colors.flower} stroke={colors.outline} strokeWidth={0.7} />)}
+      {hasFruit && accents.map((a, i) => <circle key={`fruit-${i}`} cx={20 + a.x} cy={top + a.y} r={1} fill={colors.fruit} stroke={colors.outline} strokeWidth={0.7} />)}
+    </>
+  )
+}
+
+const HEART_PATH = (x: number, y: number) =>
+  `M${x} ${(y + 1.6).toFixed(1)} C${(x - 2.6).toFixed(1)} ${(y - 0.6).toFixed(1)} ${(x - 1.1).toFixed(1)} ${(y - 2.6).toFixed(1)} ${x} ${(y - 0.9).toFixed(1)} C${(x + 1.1).toFixed(1)} ${(y - 2.6).toFixed(1)} ${(x + 2.6).toFixed(1)} ${(y - 0.6).toFixed(1)} ${x} ${(y + 1.6).toFixed(1)} Z`
+
+const StrawberryPatch = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  const count = Math.min(3 + tier, 8)
+  const baseY = 41
+  const spread = 6 + Math.min(tier, 7)
+  const parts: ReactNode[] = []
+  let tallest: { x: number; y: number } | null = null
+  const positions: { x: number; y: number }[] = []
+  for (let i = 0; i < count; i++) {
+    const t = count === 1 ? 0.5 : i / (count - 1)
+    const x = 20 + (t - 0.5) * 2 * spread
+    const riseFactor = 1 - Math.abs(t - 0.5) * 2
+    const y = baseY - (1 + riseFactor * 1.8)
+    positions.push({ x, y })
+    parts.push(<line key={`stem-${i}`} x1={x} y1={baseY} x2={x} y2={y + 1.5} stroke={colors.stem} strokeWidth={0.8} strokeLinecap="round" />)
+    parts.push(<path key={`heart-${i}`} d={HEART_PATH(x, y)} fill={colors.leaf} stroke={colors.outline} strokeWidth={0.9} />)
+    if (!tallest || y < tallest.y) tallest = { x, y }
+  }
+  return (
+    <>
+      {parts}
+      {hasFlower && tallest && <BloomCluster x={tallest.x} y={tallest.y - 2.4} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.45} />}
+      {hasFruit &&
+        positions.slice(0, 2).map((p, i) => (
+          <g key={`berry-${i}`} transform={`translate(${p.x + (i === 0 ? -1.5 : 1.8)}, ${p.y + 3})`}>
+            <path d="M0 0 L-1.6 2.6 Q0 4.4 1.6 2.6 Z" fill={colors.fruit} stroke={colors.outline} strokeWidth={0.7} />
+            <ellipse cx={0} cy={-0.3} rx={1.3} ry={0.6} fill={colors.leaf} stroke={colors.outline} strokeWidth={0.5} />
+            <circle cx={-0.5} cy={1.6} r={0.25} fill={colors.outline} opacity={0.6} />
+            <circle cx={0.6} cy={2.3} r={0.25} fill={colors.outline} opacity={0.6} />
+          </g>
+        ))}
+    </>
+  )
+}
+
+const TulipCluster = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  if (tier === 0) return null
+  const count = Math.min(1 + Math.floor(tier / 2.5), 4)
+  const baseY = 42
+  const parts: ReactNode[] = []
+  for (let i = 0; i < count; i++) {
+    const t = count === 1 ? 0.5 : i / (count - 1)
+    const x = 20 + (t - 0.5) * 10
+    const stemLen = Math.min(6 + tier * 1.8, 24)
+    const topY = baseY - stemLen
+    parts.push(<line key={`stem-${i}`} x1={x} y1={baseY} x2={x} y2={topY} stroke={colors.stem} strokeWidth={1.8} strokeLinecap="round" />)
+    if (i === 0) parts.push(<ellipse key="base-leaf" cx={x - 2} cy={baseY - 1} rx={1.6} ry={4} fill={colors.leaf} stroke={colors.outline} strokeWidth={1} transform={`rotate(-15 ${x - 2} ${baseY - 1})`} />)
+    if (hasFlower) {
+      const cup = `M${(x - 2.2).toFixed(1)} ${(topY + 3).toFixed(1)} Q${(x - 2.6).toFixed(1)} ${(topY - 1).toFixed(1)} ${(x - 0.8).toFixed(1)} ${(topY - 3).toFixed(1)} Q${x.toFixed(1)} ${(topY - 3.6).toFixed(1)} ${(x + 0.8).toFixed(1)} ${(topY - 3).toFixed(1)} Q${(x + 2.6).toFixed(1)} ${(topY - 1).toFixed(1)} ${(x + 2.2).toFixed(1)} ${(topY + 3).toFixed(1)} Q${x.toFixed(1)} ${(topY + 1.5).toFixed(1)} ${(x - 2.2).toFixed(1)} ${(topY + 3).toFixed(1)} Z`
+      parts.push(<path key={`cup-${i}`} d={cup} fill={colors.flower} stroke={colors.outline} strokeWidth={1} />)
+    } else {
+      parts.push(<ellipse key={`bud-${i}`} cx={x} cy={topY} rx={1.6} ry={2} fill={colors.leaf} stroke={colors.outline} strokeWidth={1} />)
+    }
+  }
+  return (
+    <>
+      {parts}
+      {hasFruit && <ellipse cx={20 + (count - 1) * 2.5 + 2} cy={baseY - 2} rx={1} ry={1.6} fill={colors.fruit} stroke={colors.outline} strokeWidth={0.7} />}
+    </>
+  )
+}
+
+const PumpkinVine = ({ tier, colors, hasFlower, hasFruit }: { tier: PlantTier; colors: CanopyColors; hasFlower: boolean; hasFruit: boolean }) => {
+  if (tier === 0) return null
+  const reach = Math.min(4 + tier * 1.1, 13)
+  const baseY = 42
+  const leftX = 20 - reach
+  const rightX = 20 + reach
+  const bow = baseY - 2
+  const count = Math.min(2 + Math.floor(tier / 1.5), 6)
+  const leaves: ReactNode[] = []
+  for (let i = 0; i < count; i++) {
+    const lt = count === 1 ? 0.5 : i / (count - 1)
+    const { x: lx, y: ly } = quadPoint({ x: leftX, y: baseY }, { x: 20, y: bow }, { x: rightX, y: baseY }, lt)
+    const side = i % 2 === 0 ? -1 : 1
+    leaves.push(<ellipse key={`leaf-${i}`} cx={lx} cy={ly + side * 1.6} rx={2.6} ry={2} fill={colors.leaf} stroke={colors.outline} strokeWidth={0.9} transform={`rotate(${side * 20} ${lx.toFixed(1)} ${(ly + side * 1.6).toFixed(1)})`} />)
+  }
+  return (
+    <>
+      <path d={`M${leftX} ${baseY} Q20 ${bow} ${rightX} ${baseY}`} stroke={colors.stem} strokeWidth={1.6} fill="none" strokeLinecap="round" />
+      {leaves}
+      {hasFlower && (
+        <>
+          <BloomCluster x={leftX + 2} y={baseY - 1} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.4} />
+          <BloomCluster x={rightX - 2} y={baseY - 1} color={colors.flower} glow={colors.glow} outline={colors.outline} scale={0.4} />
+        </>
+      )}
+      {hasFruit && (
+        <>
+          <circle cx={leftX + 3} cy={baseY + 1.5} r={2.6} fill={colors.fruit} stroke={colors.outline} strokeWidth={1} />
+          <rect x={leftX + 2.6} y={baseY - 1.6} width={0.8} height={1.4} fill={colors.leaf} stroke={colors.outline} strokeWidth={0.5} />
+        </>
+      )}
+    </>
+  )
+}
+
+const SpeciesCanopy = ({
+  species,
+  tier,
+  colors,
+  hasFlower,
+  hasFruit,
+}: {
+  species: PlantSpecies
+  tier: PlantTier
+  colors: CanopyColors
+  hasFlower: boolean
+  hasFruit: boolean
+}) => {
+  switch (species) {
+    case "tree":
+      return <TreeCanopy tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "cactus":
+      return <CactusBody tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "succulent":
+      return <SucculentRosette tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "fern":
+      return <FernFronds tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "vine":
+      return <VineDrape tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "bamboo":
+      return <BambooStalk tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "palm":
+      return <PalmCrown tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "mushroom":
+      return <MushroomCluster tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "pine":
+      return <PineTiers tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "clover":
+      return <CloverMound tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "orchid":
+      return <OrchidStem tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "coral":
+      return <CoralFronds tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "grass":
+      return <GrassTuft tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "lotus":
+      return <LotusPads tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "bonsai":
+      return <BonsaiPads tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "flytrap":
+      return <FlytrapJaws tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "sunflower":
+      return <SunflowerStem tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "topiary":
+      return <PomPomTopiary tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "strawberry":
+      return <StrawberryPatch tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "tulip":
+      return <TulipCluster tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "pumpkin-vine":
+      return <PumpkinVine tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+    case "flower":
+    default:
+      return <FlowerCanopy tier={tier} colors={colors} hasFlower={hasFlower} hasFruit={hasFruit} />
+  }
 }
 
 const growthBarGradients = {
@@ -468,6 +1498,16 @@ export const SeedlingPlant = ({ tier = 0, active, className, variant, showPartic
                   <circle cx="27" cy="44" r="0.5" fill={outlineColor} opacity={0.2} />
                 </>
               )}
+              {/* Cute pot face — a small constant of charm on every species, not tier-gated */}
+              {active && (
+                <>
+                  <circle cx="17" cy="47" r="0.75" fill={outlineColor} />
+                  <circle cx="23" cy="47" r="0.75" fill={outlineColor} />
+                  <path d="M17.5 48.6 Q20 50 22.5 48.6" stroke={outlineColor} strokeWidth="0.7" strokeLinecap="round" fill="none" />
+                  <circle cx="14.5" cy="48" r="1.3" fill="#f4a6c1" opacity={0.4} />
+                  <circle cx="25.5" cy="48" r="1.3" fill="#f4a6c1" opacity={0.4} />
+                </>
+              )}
               {/* Growth-points flourish: pot-rim accent (bronze/silver/gold) */}
               {active && flourishTier > 0 && (
                 <path
@@ -483,7 +1523,7 @@ export const SeedlingPlant = ({ tier = 0, active, className, variant, showPartic
 
             {/* Plant, tilted per-user via variant.stem */}
             <g transform={`rotate(${stemTilt} 20 44)`}>
-              {/* Tier 0: Dormant — plump seed in soil */}
+              {/* Tier 0: Dormant — plump seed in soil, shared by every species */}
               {tier === 0 && (
                 <g>
                   <ellipse cx="20" cy="42" rx="3" ry="2.2" fill={stemColor} stroke={outlineColor} strokeWidth="1" />
@@ -491,115 +1531,29 @@ export const SeedlingPlant = ({ tier = 0, active, className, variant, showPartic
                 </g>
               )}
 
-              {/* Tier 1: single curled sprout */}
               {tier >= 1 && (
-                <g opacity={tier >= 1 ? 1 : 0}>
+                <SpeciesCanopy
+                  species={variant?.species ?? "flower"}
+                  tier={tier}
+                  colors={{ stem: stemColor, leaf: leafColor, flower: flowerColor, fruit: fruitColor, glow: config.glowColor, outline: outlineColor }}
+                  hasFlower={config.hasFlower}
+                  hasFruit={config.hasFruit}
+                />
+              )}
+
+              {/* Sparkle crown — top tier only, floats clear above the canopy */}
+              {tier >= 9 && (
+                <>
                   <path
-                    d="M20 42 C18.5 39 18 36.5 20 34 C21 32.7 21.3 32 20.5 31"
-                    stroke={stemColor}
-                    strokeWidth="2.8"
-                    strokeLinecap="round"
-                    fill="none"
-                  />
-                  <ellipse cx="18.5" cy="31.5" rx="3.4" ry="2.2" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-35 18.5 31.5)" />
-                </g>
-              )}
-
-              {/* Tier 2: twin round leaf pair + tiny topknot */}
-              {tier >= 2 && (
-                <g opacity={tier >= 2 ? 1 : 0}>
-                  <path d="M20 42 L20 29" stroke={stemColor} strokeWidth="3" strokeLinecap="round" />
-                  <ellipse cx="15" cy="33" rx="3.6" ry="2.4" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-30 15 33)" />
-                  <ellipse cx="25" cy="33" rx="3.6" ry="2.4" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(30 25 33)" />
-                  <circle cx="20" cy="28" r="2" fill={leafColor} stroke={outlineColor} strokeWidth="1.2" />
-                </g>
-              )}
-
-              {/* Tier 3: fuller canopy + closed bud */}
-              {tier >= 3 && (
-                <g opacity={tier >= 3 ? 1 : 0}>
-                  <path d="M20 42 Q21 36 19.5 30 Q19 26 20 22" stroke={stemColor} strokeWidth="3.2" strokeLinecap="round" fill="none" />
-                  <ellipse cx="14.5" cy="35" rx="4" ry="2.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-30 14.5 35)" />
-                  <ellipse cx="25.5" cy="35" rx="4" ry="2.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(30 25.5 35)" />
-                  <ellipse cx="13" cy="27" rx="3.6" ry="2.4" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-35 13 27)" />
-                  <ellipse cx="27" cy="27" rx="3.6" ry="2.4" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(35 27 27)" />
-                  {/* Closed bud — same overlapping-petal motif as the tier 4/5 bloom, drawn tight and unopened */}
-                  <ellipse cx="17.6" cy="23.5" rx="2.2" ry="1.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.2" transform="rotate(-30 17.6 23.5)" />
-                  <ellipse cx="22.4" cy="23.5" rx="2.2" ry="1.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.2" transform="rotate(30 22.4 23.5)" />
-                  <g transform="translate(20, 20)">
-                    <circle cx="0" cy="-1.5" r="2.2" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                    <circle cx="-1.8" cy="1" r="2.2" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                    <circle cx="1.8" cy="1" r="2.2" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                    <ellipse cx="-0.7" cy="-2" rx="0.7" ry="0.9" fill="white" opacity={0.4} />
-                  </g>
-                </g>
-              )}
-
-              {/* Tier 4: open chunky bloom + denser canopy */}
-              {tier >= 4 && (
-                <g opacity={tier >= 4 ? 1 : 0}>
-                  <path d="M20 42 Q21.5 36 20 30 Q19 26 20 19" stroke={stemColor} strokeWidth="3.4" strokeLinecap="round" fill="none" />
-                  <ellipse cx="13.5" cy="37" rx="4.2" ry="2.7" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(-32 13.5 37)" />
-                  <ellipse cx="26.5" cy="37" rx="4.2" ry="2.7" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(32 26.5 37)" />
-                  <ellipse cx="12.5" cy="29" rx="3.8" ry="2.5" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(-38 12.5 29)" />
-                  <ellipse cx="27.5" cy="29" rx="3.8" ry="2.5" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(38 27.5 29)" />
-                  <ellipse cx="14.5" cy="23" rx="3.2" ry="2.1" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-40 14.5 23)" />
-                  <ellipse cx="25.5" cy="23" rx="3.2" ry="2.1" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(40 25.5 23)" />
-                  {/* Chunky open bloom: 5-petal circle cluster */}
-                  <g transform="translate(20, 16)">
-                    {[0, 72, 144, 216, 288].map((angle) => {
-                      const rad = (angle * Math.PI) / 180
-                      const px = Math.cos(rad) * 3.4
-                      const py = Math.sin(rad) * 3.4
-                      return <circle key={angle} cx={px} cy={py} r="2.6" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                    })}
-                    <circle cx="0" cy="0" r="2" fill={config.glowColor} stroke={outlineColor} strokeWidth="0.8" />
-                  </g>
-                </g>
-              )}
-
-              {/* Tier 5: bloom + two plump fruits + sparkle crown */}
-              {tier >= 5 && (
-                <g opacity={tier >= 5 ? 1 : 0}>
-                  <path d="M20 42 Q22 35 20 28 Q19 24 20 17" stroke={stemColor} strokeWidth="3.6" strokeLinecap="round" fill="none" />
-                  <ellipse cx="13" cy="37" rx="4.4" ry="2.8" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(-32 13 37)" />
-                  <ellipse cx="27" cy="37" rx="4.4" ry="2.8" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(32 27 37)" />
-                  <ellipse cx="11.5" cy="28" rx="4" ry="2.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(-38 11.5 28)" />
-                  <ellipse cx="28.5" cy="28" rx="4" ry="2.6" fill={leafColor} stroke={outlineColor} strokeWidth="1.5" transform="rotate(38 28.5 28)" />
-                  <ellipse cx="14" cy="22" rx="3.4" ry="2.2" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(-40 14 22)" />
-                  <ellipse cx="26" cy="22" rx="3.4" ry="2.2" fill={leafColor} stroke={outlineColor} strokeWidth="1.4" transform="rotate(40 26 22)" />
-                  {/* Bloom */}
-                  <g transform="translate(20, 14)">
-                    {[0, 72, 144, 216, 288].map((angle) => {
-                      const rad = (angle * Math.PI) / 180
-                      const px = Math.cos(rad) * 3.6
-                      const py = Math.sin(rad) * 3.6
-                      return <circle key={angle} cx={px} cy={py} r="2.8" fill={flowerColor} stroke={outlineColor} strokeWidth="1" />
-                    })}
-                    <circle cx="0" cy="0" r="2.2" fill={config.glowColor} stroke={outlineColor} strokeWidth="0.8" />
-                  </g>
-                  {/* Sparkle crown — floats clear above the bloom instead of cutting through it */}
-                  <path
-                    d="M20 1.7 L20.7 3.8 L22.8 4.5 L20.7 5.2 L20 7.3 L19.3 5.2 L17.2 4.5 L19.3 3.8 Z"
+                    d={`M20 ${canopyTop(tier) - 13} L20.7 ${canopyTop(tier) - 10.9} L22.8 ${canopyTop(tier) - 10.2} L20.7 ${canopyTop(tier) - 9.5} L20 ${canopyTop(tier) - 7.4} L19.3 ${canopyTop(tier) - 9.5} L17.2 ${canopyTop(tier) - 10.2} L19.3 ${canopyTop(tier) - 10.9} Z`}
                     fill={config.glowColor}
                     stroke={outlineColor}
                     strokeWidth="0.6"
                     opacity={0.95}
                   />
-                  <circle cx="25" cy="6.5" r="0.9" fill={config.glowColor} opacity={0.8} />
-                  <circle cx="15" cy="7.5" r="0.6" fill={config.glowColor} opacity={0.7} />
-                  {/* Fruit — plump, with a small leafy calyx instead of a bare line */}
-                  <g transform="translate(14.5, 33)">
-                    <circle cx="0" cy="0" r="3.8" fill={fruitColor} stroke={outlineColor} strokeWidth="1.3" />
-                    <ellipse cx="0.3" cy="-3.6" rx="1.1" ry="0.7" fill={leafColor} stroke={outlineColor} strokeWidth="0.7" transform="rotate(20 0.3 -3.6)" />
-                    <circle cx="-1.1" cy="-1.1" r="1.1" fill="white" opacity={0.4} />
-                  </g>
-                  <g transform="translate(26.5, 26)">
-                    <circle cx="0" cy="0" r="3" fill={fruitColor} stroke={outlineColor} strokeWidth="1.1" />
-                    <ellipse cx="0.25" cy="-2.8" rx="0.9" ry="0.6" fill={leafColor} stroke={outlineColor} strokeWidth="0.6" transform="rotate(20 0.25 -2.8)" />
-                    <circle cx="-0.9" cy="-0.9" r="0.9" fill="white" opacity={0.35} />
-                  </g>
-                </g>
+                  <circle cx="25" cy={canopyTop(tier) - 8.2} r="0.9" fill={config.glowColor} opacity={0.8} />
+                  <circle cx="15" cy={canopyTop(tier) - 7.2} r="0.6" fill={config.glowColor} opacity={0.7} />
+                </>
               )}
             </g>
           </svg>

--- a/src/lib/plant-variants.test.ts
+++ b/src/lib/plant-variants.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { getPlantVariant, getUnlockedPalettes, getPaletteUnlockTier, getAllPalettes } from "./plant-variants";
+import { getPlantVariant, getAllPalettes } from "./plant-variants";
 
 describe("getPlantVariant palette override", () => {
-  it("applies the override when given an unlocked palette name", () => {
+  it("applies the override when given a valid palette name", () => {
     const base = getPlantVariant("user-123");
     const overridden = getPlantVariant("user-123", "Ocean");
 
@@ -12,6 +12,7 @@ describe("getPlantVariant palette override", () => {
     expect(overridden.leaf).toBe(base.leaf);
     expect(overridden.flower).toBe(base.flower);
     expect(overridden.stem).toBe(base.stem);
+    expect(overridden.species).toBe(base.species);
   });
 
   it("falls back to the hash-derived default when no override is given", () => {
@@ -25,33 +26,23 @@ describe("getPlantVariant palette override", () => {
     const unknownOverride = getPlantVariant("user-123", "Not A Real Palette");
     expect(unknownOverride.palette.name).toBe(base.palette.name);
   });
-});
 
-describe("palette unlock progression", () => {
-  it("unlocks no palettes below tier 2", () => {
-    expect(getUnlockedPalettes(0)).toHaveLength(0);
-    expect(getUnlockedPalettes(1)).toHaveLength(0);
-  });
-
-  it("unlocks all palettes at max tier", () => {
-    expect(getUnlockedPalettes(5)).toHaveLength(getAllPalettes().length);
-  });
-
-  it("is cumulative — every palette unlocked at a tier stays unlocked at higher tiers", () => {
-    const tiers = [0, 1, 2, 3, 4, 5] as const;
-    for (let i = 0; i < tiers.length - 1; i++) {
-      expect(getUnlockedPalettes(tiers[i]).length).toBeLessThanOrEqual(getUnlockedPalettes(tiers[i + 1]).length);
+  it("is deterministic per userId and picks a species from the full pool", () => {
+    const species = new Set([
+      "flower", "cactus", "succulent", "tree", "fern", "vine", "bamboo", "palm",
+      "mushroom", "pine", "clover", "orchid", "coral", "grass", "lotus", "bonsai", "flytrap",
+      "sunflower", "topiary", "strawberry", "tulip", "pumpkin-vine",
+    ]);
+    for (const id of ["a", "b", "c", "d", "e", "f"]) {
+      const variant = getPlantVariant(id);
+      expect(species.has(variant.species)).toBe(true);
+      expect(getPlantVariant(id)).toEqual(variant);
     }
   });
+});
 
-  it("getPaletteUnlockTier matches getUnlockedPalettes boundaries", () => {
-    const all = getAllPalettes();
-    all.forEach((_, index) => {
-      const tier = getPaletteUnlockTier(index);
-      expect(getUnlockedPalettes(tier).length).toBeGreaterThan(index);
-      if (tier > 0) {
-        expect(getUnlockedPalettes((tier - 1) as 0 | 1 | 2 | 3 | 4).length).toBeLessThanOrEqual(index);
-      }
-    });
+describe("getAllPalettes", () => {
+  it("returns every palette, unlock-free", () => {
+    expect(getAllPalettes().length).toBeGreaterThanOrEqual(16);
   });
 });

--- a/src/lib/plant-variants.ts
+++ b/src/lib/plant-variants.ts
@@ -1,5 +1,3 @@
-import type { PlantTier } from "@/lib/streak-milestones"
-
 /* ─── Seeded PRNG ─── */
 
 function hashString(str: string): number {
@@ -31,6 +29,7 @@ export interface PlantPalette {
   pot: string
 }
 
+// ponytail: names here mirror validPlantPalettes in baro-gofiber/internal/handler/user_handler.go — keep in sync
 const PALETTES: PlantPalette[] = [
   {
     name: "Forest",
@@ -132,6 +131,66 @@ const PALETTES: PlantPalette[] = [
     soil: "#3e2723",
     pot: "#6d4c41",
   },
+  {
+    name: "Jade",
+    stem: "#1e5631",
+    leaf: "#3f8a5c",
+    flower: "#a8e6a3",
+    fruit: "#d9f2b4",
+    glow: "#52c77e",
+    soil: "#3e2723",
+    pot: "#6d8a6d",
+  },
+  {
+    name: "Berry",
+    stem: "#6a1b4d",
+    leaf: "#8e3b6a",
+    flower: "#c2185b",
+    fruit: "#ad1457",
+    glow: "#ec407a",
+    soil: "#3e2723",
+    pot: "#7b4b5a",
+  },
+  {
+    name: "Citrus",
+    stem: "#558b2f",
+    leaf: "#9ccc65",
+    flower: "#fff59d",
+    fruit: "#ffb300",
+    glow: "#cddc39",
+    soil: "#4e342e",
+    pot: "#ef6c00",
+  },
+  {
+    name: "Slate",
+    stem: "#37474f",
+    leaf: "#607d8b",
+    flower: "#b0bec5",
+    fruit: "#cfd8dc",
+    glow: "#90a4ae",
+    soil: "#263238",
+    pot: "#455a64",
+  },
+  {
+    name: "Blush",
+    stem: "#ad7a99",
+    leaf: "#d8a7c4",
+    flower: "#ffc1e3",
+    fruit: "#ffd6ec",
+    glow: "#f48fb1",
+    soil: "#4e342e",
+    pot: "#c48b9f",
+  },
+  {
+    name: "Midnight",
+    stem: "#1a237e",
+    leaf: "#3949ab",
+    flower: "#7986cb",
+    fruit: "#9fa8da",
+    glow: "#5c6bc0",
+    soil: "#263238",
+    pot: "#303f9f",
+  },
 ]
 
 /* ─── Pot Shapes ─── */
@@ -186,6 +245,70 @@ const STEM_TILTS: Record<StemStyle, number> = {
   leaning: 5,
 }
 
+/* ─── Species ─── */
+
+// Different growth topologies, not just recolors: flower/tree grow a canopy of
+// leaf pairs up a stem, cactus stacks round paddle segments, succulent radiates
+// a rosette from the pot rim, fern fans curved fronds from the base, vine drapes
+// leaflets down over the pot rim, bamboo stacks thin jointed stalks, palm tops a
+// bare trunk with a radiating frond crown, mushroom clusters cap-on-stalk fungi,
+// pine stacks triangular tiers, clover mounds low trefoil clusters, orchid arches
+// a sparse stem of butterfly blossoms, coral waves thick bulb-tipped tentacles,
+// grass fans thin blades from the base, lotus floats flat pads with a rising bloom,
+// bonsai layers flat pads along a zigzag trunk, flytrap radiates paired trap jaws,
+// sunflower tops a bare stem with one big flower head, topiary balls a single
+// round crown on a stick, strawberry mounds heart leaves with hanging berries,
+// tulip clusters cup-shaped blooms on straight stems, pumpkin-vine creeps low
+// and horizontal with gourds resting on the soil. See SpeciesCanopy in streak-components.tsx.
+export type PlantSpecies =
+  | "flower"
+  | "cactus"
+  | "succulent"
+  | "tree"
+  | "fern"
+  | "vine"
+  | "bamboo"
+  | "palm"
+  | "mushroom"
+  | "pine"
+  | "clover"
+  | "orchid"
+  | "coral"
+  | "grass"
+  | "lotus"
+  | "bonsai"
+  | "flytrap"
+  | "sunflower"
+  | "topiary"
+  | "strawberry"
+  | "tulip"
+  | "pumpkin-vine"
+
+const SPECIES: PlantSpecies[] = [
+  "flower",
+  "cactus",
+  "succulent",
+  "tree",
+  "fern",
+  "vine",
+  "bamboo",
+  "palm",
+  "mushroom",
+  "pine",
+  "clover",
+  "orchid",
+  "coral",
+  "grass",
+  "lotus",
+  "bonsai",
+  "flytrap",
+  "sunflower",
+  "topiary",
+  "strawberry",
+  "tulip",
+  "pumpkin-vine",
+]
+
 /* ─── Variant Config ─── */
 
 export interface PlantVariantConfig {
@@ -194,6 +317,7 @@ export interface PlantVariantConfig {
   leaf: LeafStyle
   flower: FlowerType
   stem: StemStyle
+  species: PlantSpecies
 }
 
 export function getPlantVariant(userId: string, paletteOverride?: string): PlantVariantConfig {
@@ -209,59 +333,12 @@ export function getPlantVariant(userId: string, paletteOverride?: string): Plant
     leaf: (["rounded", "pointed", "wide"] as LeafStyle[])[Math.floor(rand() * 3)],
     flower: (["daisy", "tulip", "star"] as FlowerType[])[Math.floor(rand() * 3)],
     stem: (["straight", "curved", "leaning"] as StemStyle[])[Math.floor(rand() * 3)],
+    species: SPECIES[Math.floor(rand() * SPECIES.length)],
   }
-}
-
-/* ─── Unlockable palette progression ─── */
-
-// ponytail: mirrors validPlantPalettes in baro-gofiber/internal/handler/user_handler.go — keep in sync
-const PALETTE_UNLOCK_COUNTS: Record<PlantTier, number> = { 0: 0, 1: 0, 2: 3, 3: 5, 4: 7, 5: 10 }
-
-export function getUnlockedPalettes(tier: PlantTier): PlantPalette[] {
-  return PALETTES.slice(0, PALETTE_UNLOCK_COUNTS[tier])
 }
 
 export function getAllPalettes(): PlantPalette[] {
   return PALETTES
-}
-
-// The tier at which the palette at this index (into getAllPalettes()) becomes selectable.
-export function getPaletteUnlockTier(index: number): PlantTier {
-  const tiers: PlantTier[] = [0, 1, 2, 3, 4, 5]
-  for (const tier of tiers) {
-    if (index < PALETTE_UNLOCK_COUNTS[tier]) return tier
-  }
-  return 5
-}
-
-/* ─── Tier-specific leaf positions ─── */
-
-interface LeafPos {
-  x: number
-  y: number
-}
-
-const LEAF_POSITIONS: Record<PlantTier, LeafPos[]> = {
-  0: [],
-  1: [{ x: 20, y: 36 }],
-  2: [
-    { x: 20, y: 36 },
-    { x: 20, y: 31 },
-  ],
-  3: [
-    { x: 20.5, y: 38 },
-    { x: 19.5, y: 30 },
-  ],
-  4: [
-    { x: 20.5, y: 38 },
-    { x: 20, y: 30 },
-    { x: 20, y: 24 },
-  ],
-  5: [
-    { x: 21, y: 38 },
-    { x: 20, y: 28 },
-    { x: 20, y: 22 },
-  ],
 }
 
 /* ─── Exported utilities ─── */
@@ -276,32 +353,4 @@ export function getLeafPath(style: LeafStyle): string {
 
 export function getStemTilt(style: StemStyle): number {
   return STEM_TILTS[style]
-}
-
-export function getLeafPositions(tier: PlantTier): LeafPos[] {
-  return LEAF_POSITIONS[tier] ?? []
-}
-
-export function getFlowerPosition(tier: PlantTier): { x: number; y: number } | null {
-  if (tier >= 5) return { x: 20, y: 15 }
-  if (tier >= 4) return { x: 20, y: 17 }
-  if (tier >= 3) return { x: 20, y: 21 }
-  return null
-}
-
-export function getStemPath(tier: PlantTier): string {
-  switch (tier) {
-    case 1:
-      return "M20 42 Q19 40 20.5 37 Q21 35 20 33"
-    case 2:
-      return "M20 42 L20 30"
-    case 3:
-      return "M20 42 Q21 36 19.5 30 Q19 26 20 22"
-    case 4:
-      return "M20 42 Q21.5 36 20 30 Q19 26 20 20"
-    case 5:
-      return "M20 42 Q22 35 20 28 Q19 24 20 18"
-    default:
-      return ""
-  }
 }

--- a/src/lib/streak-milestones.ts
+++ b/src/lib/streak-milestones.ts
@@ -75,7 +75,7 @@ export function getRandomComfortMessage(type: keyof typeof comfortZoneMessages):
   return messages[Math.floor(Math.random() * messages.length)]
 }
 
-export type PlantTier = 0 | 1 | 2 | 3 | 4 | 5
+export type PlantTier = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
 
 export type GrowthGlowStyle = "none" | "glow" | "radiant" | "bloom" | "bloom-ring" | "aurora"
 
@@ -115,14 +115,14 @@ const PLANT_TIER_CONFIGS: Record<PlantTier, PlantTierConfig> = {
   },
   1: {
     name: "sprout",
-    stemColor: "#a5d6a7",
-    leafColor: "#c8e6c9",
+    stemColor: "#b9dab9",
+    leafColor: "#d3ecd4",
     flowerColor: "#e8f5e9",
-    fruitColor: "#a5d6a7",
+    fruitColor: "#b9dab9",
     glowColor: "#a5d6a7",
     soilColor: "#5c4033",
     potColor: "#c77d61",
-    particleCount: 3,
+    particleCount: 2,
     particleTypes: ["pollen"],
     glowScale: 1,
     hasFlower: false,
@@ -130,77 +130,144 @@ const PLANT_TIER_CONFIGS: Record<PlantTier, PlantTierConfig> = {
     growthGlow: "glow",
   },
   2: {
-    name: "seedling",
-    stemColor: "#66bb6a",
-    leafColor: "#81c784",
-    flowerColor: "#a5d6a7",
-    fruitColor: "#66bb6a",
-    glowColor: "#66bb6a",
+    name: "sprouting",
+    stemColor: "#a5d6a7",
+    leafColor: "#c8e6c9",
+    flowerColor: "#e8f5e9",
+    fruitColor: "#a5d6a7",
+    glowColor: "#8fd08f",
     soilColor: "#5c4033",
     potColor: "#c77d61",
-    particleCount: 5,
-    particleTypes: ["pollen", "leaf"],
-    glowScale: 1.15,
+    particleCount: 3,
+    particleTypes: ["pollen"],
+    glowScale: 1.05,
     hasFlower: false,
     hasFruit: false,
     growthGlow: "glow",
   },
   3: {
-    name: "growing",
-    stemColor: "#43a047",
-    leafColor: "#66bb6a",
-    flowerColor: "#f8bbd0",
-    fruitColor: "#66bb6a",
-    glowColor: "#43a047",
+    name: "seedling",
+    stemColor: "#8bc98f",
+    leafColor: "#b7ddb9",
+    flowerColor: "#dcedc8",
+    fruitColor: "#8bc98f",
+    glowColor: "#7cc97f",
     soilColor: "#5c4033",
     potColor: "#c77d61",
-    particleCount: 7,
+    particleCount: 5,
+    particleTypes: ["pollen", "leaf"],
+    glowScale: 1.1,
+    hasFlower: false,
+    hasFruit: false,
+    growthGlow: "glow",
+  },
+  4: {
+    name: "budding",
+    stemColor: "#74bc79",
+    leafColor: "#9ed3a1",
+    flowerColor: "#dcedc8",
+    fruitColor: "#74bc79",
+    glowColor: "#66bb6a",
+    soilColor: "#5c4033",
+    potColor: "#c77d61",
+    particleCount: 6,
+    particleTypes: ["pollen", "leaf"],
+    glowScale: 1.15,
+    hasFlower: false,
+    hasFruit: false,
+    growthGlow: "radiant",
+  },
+  5: {
+    name: "growing",
+    stemColor: "#66bb6a",
+    leafColor: "#8fc793",
+    flowerColor: "#c8e6c9",
+    fruitColor: "#66bb6a",
+    glowColor: "#57b25c",
+    soilColor: "#5c4033",
+    potColor: "#c77d61",
+    particleCount: 8,
+    particleTypes: ["pollen", "leaf"],
+    glowScale: 1.2,
+    hasFlower: false,
+    hasFruit: false,
+    growthGlow: "radiant",
+  },
+  6: {
+    name: "flourishing",
+    stemColor: "#52a855",
+    leafColor: "#7cba80",
+    flowerColor: "#f8bbd0",
+    fruitColor: "#52a855",
+    glowColor: "#4caf50",
+    soilColor: "#5c4033",
+    potColor: "#c77d61",
+    particleCount: 9,
     particleTypes: ["pollen", "leaf", "petal"],
     glowScale: 1.3,
     hasFlower: true,
     hasFruit: false,
     growthGlow: "radiant",
   },
-  4: {
+  7: {
     name: "blooming",
-    stemColor: "#2e7d32",
-    leafColor: "#43a047",
+    stemColor: "#43a047",
+    leafColor: "#66bb6a",
     flowerColor: "#f48fb1",
-    fruitColor: "#43a047",
-    glowColor: "#2e7d32",
+    fruitColor: "#66bb6a",
+    glowColor: "#43a047",
     soilColor: "#5c4033",
     potColor: "#b56a4e",
-    particleCount: 9,
-    particleTypes: ["pollen", "leaf", "petal", "light"],
-    glowScale: 1.45,
+    particleCount: 11,
+    particleTypes: ["pollen", "leaf", "petal"],
+    glowScale: 1.4,
     hasFlower: true,
     hasFruit: false,
     growthGlow: "bloom",
   },
-  5: {
+  8: {
     name: "fruitful",
-    stemColor: "#1b5e20",
-    leafColor: "#2e7d32",
+    stemColor: "#2e7d32",
+    leafColor: "#43a047",
     flowerColor: "#f48fb1",
     fruitColor: "#e9c46a",
     glowColor: "#e9c46a",
     soilColor: "#5c4033",
     potColor: "#b56a4e",
-    particleCount: 12,
+    particleCount: 13,
     particleTypes: ["pollen", "leaf", "petal", "light"],
-    glowScale: 1.6,
+    glowScale: 1.5,
+    hasFlower: true,
+    hasFruit: true,
+    growthGlow: "bloom",
+  },
+  9: {
+    name: "bountiful",
+    stemColor: "#1b5e20",
+    leafColor: "#2e7d32",
+    flowerColor: "#f06292",
+    fruitColor: "#ffd700",
+    glowColor: "#ffd700",
+    soilColor: "#5c4033",
+    potColor: "#b56a4e",
+    particleCount: 16,
+    particleTypes: ["pollen", "leaf", "petal", "light"],
+    glowScale: 1.65,
     hasFlower: true,
     hasFruit: true,
     growthGlow: "aurora",
   },
 }
 
+// Denser early tiers (streaks under 30 days flip stages every few days) plus
+// extended late tiers (up to 100 days) so long streaks keep visibly evolving.
+const TIER_DAY_BOUNDARIES: Record<PlantTier, number> = { 0: 0, 1: 1, 2: 3, 3: 7, 4: 14, 5: 21, 6: 30, 7: 50, 8: 75, 9: 100 }
+
 export function getPlantTier(streak: number): PlantTier {
-  if (streak >= 50) return 5
-  if (streak >= 30) return 4
-  if (streak >= 20) return 3
-  if (streak >= 10) return 2
-  if (streak >= 1) return 1
+  const tiers: PlantTier[] = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+  for (const tier of tiers) {
+    if (streak >= TIER_DAY_BOUNDARIES[tier]) return tier
+  }
   return 0
 }
 
@@ -213,10 +280,8 @@ export function getEffectivePlantDays(streak: number, growthPoints: number): num
   return streak + Math.floor(growthPoints / GROWTH_POINTS_PER_DAY)
 }
 
-const TIER_THRESHOLDS: Record<PlantTier, number> = { 0: 0, 1: 1, 2: 10, 3: 20, 4: 30, 5: 50 }
-
 export function getTierDayThreshold(tier: PlantTier): number {
-  return TIER_THRESHOLDS[tier]
+  return TIER_DAY_BOUNDARIES[tier]
 }
 
 export type FlourishTier = 0 | 1 | 2 | 3
@@ -239,9 +304,9 @@ export function getFlourishTier(growthPoints: number): FlourishTier {
 export function getNextTierProgress(streak: number, growthPoints = 0): { current: number; max: number; isMaxTier: boolean } {
   const days = getEffectivePlantDays(streak, growthPoints)
   const tier = getPlantTier(days)
-  if (tier === 5) return { current: days, max: days, isMaxTier: true }
-  const next = TIER_THRESHOLDS[(tier + 1) as PlantTier]
-  const prev = TIER_THRESHOLDS[tier]
+  if (tier === 9) return { current: days, max: days, isMaxTier: true }
+  const next = TIER_DAY_BOUNDARIES[(tier + 1) as PlantTier]
+  const prev = TIER_DAY_BOUNDARIES[tier]
   return { current: days - prev, max: next - prev, isMaxTier: false }
 }
 

--- a/src/pages/admin-users-page.tsx
+++ b/src/pages/admin-users-page.tsx
@@ -41,11 +41,13 @@ interface ApiResponse {
 
 type Tab = "users" | "register" | "salesforce";
 
+const LAST_COHORT_KEY = "admin-users-last-cohort";
+
 export function AdminUsersPage() {
   const [users, setUsers] = useState<User[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [searchParams, setSearchParams] = useSearchParams();
-  const cohort = searchParams.get("cohort") || "0";
+  const cohort = searchParams.get("cohort") || localStorage.getItem(LAST_COHORT_KEY) || "0";
   const [activeTab, setActiveTab] = useState<Tab>("users");
   const [isBulkRegisterOpen, setIsBulkRegisterOpen] = useState(false);
 
@@ -97,6 +99,7 @@ export function AdminUsersPage() {
               Cohort:
             </label>
             <Select value={cohort} onValueChange={(value) => {
+              localStorage.setItem(LAST_COHORT_KEY, value);
               setSearchParams((prev) => {
                 if (value === "0") {
                   prev.delete("cohort");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added five plant palettes and expanded plant variety to 22 species and forms.
  - Expanded plant growth progression from 6 to 10 stages, with new visual designs and milestone appearances.
  - Added species-specific plant canopies, consistent pot styling, and sparkle effects for highest-tier plants.
  - All palettes are now available for selection without unlock restrictions.
  - Admin cohort selections now persist between visits.

- **Bug Fixes**
  - Corrected the Select All action in bulk user management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->