### PR TITLE
fix: unwrap barometer chart response envelope

### DIFF
--- a/src/application/services/reflectionService.ts
+++ b/src/application/services/reflectionService.ts
@@ -1,5 +1,6 @@
 import { api } from "../../infrastructure/api";
 import type {
+  ApiResponse,
   WeeklyReflection,
   BarometerData,
   CreateReflectionPayload,
@@ -20,8 +21,8 @@ export const reflectionService = {
     if (cohort) {
       url += `&cohort=${cohort}`;
     }
-    const response = await api.get<BarometerData[]>(url);
-    return response.data;
+    const response = await api.get<ApiResponse<BarometerData[]>>(url);
+    return response.data.data;
   },
 };
 


### PR DESCRIPTION
getBarometerData read response.data directly as the chart array, but /admin/reflections/chartday wraps its payload in {status, message, data} like every other endpoint. Array.isArray() on the envelope object silently failed, so the admin dashboard's Reflection Zones chart always rendered empty (0/0, no graph) even when the backend had real data.