### PR TITLE
Feat/reward pots and plant preview

### DIFF
--- a/src/components/admin-plant-override-button.tsx
+++ b/src/components/admin-plant-override-button.tsx
@@ -7,13 +7,19 @@ import { Sprout } from "lucide-react";
 import { userService } from "@/lib/api";
 import {
   getAllPalettes,
+  getPlantVariant,
   SPECIES,
   POT_STYLES,
   LEAF_STYLES,
   FLOWER_TYPES,
   STEM_STYLES,
 } from "@/lib/plant-variants";
+import { SeedlingPlant } from "@/components/streak-components";
 import { toast } from "sonner";
+
+// Preview always shows the fully-grown look (tier 9) so every part — flower,
+// fruit, etc. — is visible regardless of the learner's actual streak.
+const PREVIEW_TIER = 9;
 
 // Radix Select can't represent an empty string value, so "auto" stands in for
 // "no override — use the hash-derived default" and is converted to "" on submit.
@@ -78,6 +84,16 @@ export function AdminPlantOverrideButton({ userId, current, onSaved }: AdminPlan
             <Sprout className="h-5 w-5" /> Edit Plant
           </DialogTitle>
         </DialogHeader>
+
+        <div className="flex justify-center py-2">
+          <SeedlingPlant
+            tier={PREVIEW_TIER}
+            active
+            showParticles={false}
+            variant={getPlantVariant(userId, values)}
+            className="h-28 w-24"
+          />
+        </div>
 
         <div className="grid grid-cols-2 gap-4">
           {FIELDS.map(({ key, label, options }) => (

--- a/src/components/admin-plant-override-button.tsx
+++ b/src/components/admin-plant-override-button.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogFooter } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel } from "@/components/ui/select";
 import { Sprout } from "lucide-react";
 import { userService } from "@/lib/api";
 import {
@@ -10,6 +10,8 @@ import {
   getPlantVariant,
   SPECIES,
   POT_STYLES,
+  SPECIAL_POT_STYLES,
+  SPECIAL_POT_LABELS,
   LEAF_STYLES,
   FLOWER_TYPES,
   STEM_STYLES,
@@ -38,14 +40,29 @@ interface AdminPlantOverrideButtonProps {
   onSaved?: () => void;
 }
 
-const FIELDS: { key: keyof AdminPlantOverrideButtonProps["current"]; label: string; options: string[] }[] = [
-  { key: "palette", label: "Color", options: getAllPalettes().map((p) => p.name) },
-  { key: "species", label: "Species", options: SPECIES },
-  { key: "pot", label: "Pot", options: POT_STYLES },
-  { key: "leaf", label: "Leaf", options: LEAF_STYLES },
-  { key: "flower", label: "Flower", options: FLOWER_TYPES },
-  { key: "stem", label: "Stem", options: STEM_STYLES },
+const FIELDS: {
+  key: keyof AdminPlantOverrideButtonProps["current"];
+  label: string;
+  groups: { label?: string; options: string[] }[];
+}[] = [
+  { key: "palette", label: "Color", groups: [{ options: getAllPalettes().map((p) => p.name) }] },
+  { key: "species", label: "Species", groups: [{ options: SPECIES }] },
+  {
+    key: "pot",
+    label: "Pot",
+    groups: [
+      { label: "Basic", options: POT_STYLES },
+      { label: "Reward (admin-only)", options: SPECIAL_POT_STYLES },
+    ],
+  },
+  { key: "leaf", label: "Leaf", groups: [{ options: LEAF_STYLES }] },
+  { key: "flower", label: "Flower", groups: [{ options: FLOWER_TYPES }] },
+  { key: "stem", label: "Stem", groups: [{ options: STEM_STYLES }] },
 ];
+
+function optionLabel(option: string): string {
+  return SPECIAL_POT_LABELS[option as keyof typeof SPECIAL_POT_LABELS] ?? option;
+}
 
 export function AdminPlantOverrideButton({ userId, current, onSaved }: AdminPlantOverrideButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -96,7 +113,7 @@ export function AdminPlantOverrideButton({ userId, current, onSaved }: AdminPlan
         </div>
 
         <div className="grid grid-cols-2 gap-4">
-          {FIELDS.map(({ key, label, options }) => (
+          {FIELDS.map(({ key, label, groups }) => (
             <div key={key} className="space-y-2">
               <Label htmlFor={`plant-${key}`}>{label}</Label>
               <Select
@@ -108,10 +125,15 @@ export function AdminPlantOverrideButton({ userId, current, onSaved }: AdminPlan
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value={AUTO}>Auto (default)</SelectItem>
-                  {options.map((option) => (
-                    <SelectItem key={option} value={option}>
-                      {option}
-                    </SelectItem>
+                  {groups.map((group, gi) => (
+                    <SelectGroup key={gi}>
+                      {group.label && <SelectLabel>{group.label}</SelectLabel>}
+                      {group.options.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {optionLabel(option)}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
                   ))}
                 </SelectContent>
               </Select>

--- a/src/components/streak-components.tsx
+++ b/src/components/streak-components.tsx
@@ -17,7 +17,15 @@ import {
 
 import { Cat } from "lucide-react"
 import { fireConfetti } from "@/lib/confetti"
-import { getPotPath, getStemTilt, type PlantVariantConfig, type PlantSpecies } from "@/lib/plant-variants"
+import {
+  getPotPath,
+  getStemTilt,
+  isSpecialPotStyle,
+  getSpecialPotColor,
+  type PlantVariantConfig,
+  type PlantSpecies,
+  type SpecialPotStyle,
+} from "@/lib/plant-variants"
 
 const tierTextColors: Record<PlantTier, string> = {
   0: "text-muted-foreground",
@@ -1317,6 +1325,186 @@ const AuraGlow = ({
   />
 )
 
+/* ─── Special reward pot decorations ───
+   Fixed, palette-independent decoration for each admin-only reward pot — the whole point
+   is that these don't recolor with the learner's palette like the 4 basic pots do. */
+
+const TrophyDecoration = () => (
+  <>
+    <path d="M7 44 L33 44 L31 41 L9 41 Z" fill="none" stroke="#d4af37" strokeWidth={1.4} />
+    <path d="M7.5 42.5 C4.5 42.5 4.5 46.5 7.5 46.5" fill="none" stroke="#d4af37" strokeWidth={1.3} />
+    <path d="M32.5 42.5 C35.5 42.5 35.5 46.5 32.5 46.5" fill="none" stroke="#d4af37" strokeWidth={1.3} />
+    <ellipse cx={16} cy={47.5} rx={3.5} ry={1} fill="#d4af37" opacity={0.35} />
+  </>
+)
+
+const StarlightDecoration = () => (
+  <>
+    <path d="M8 42 L32 42 L30 39 L10 39 Z" fill="none" stroke="#cfd8ff" strokeWidth={1} opacity={0.8} />
+    {[[14, 47], [24, 45.5], [19, 49], [27, 48]].map(([x, y], i) => (
+      <path
+        key={i}
+        d={`M${x} ${y - 0.9} L${x + 0.3} ${y - 0.2} L${x + 0.9} ${y} L${x + 0.3} ${y + 0.2} L${x} ${y + 0.9} L${x - 0.3} ${y + 0.2} L${x - 0.9} ${y} L${x - 0.3} ${y - 0.2} Z`}
+        fill="#f4e9c1"
+      />
+    ))}
+  </>
+)
+
+const RainbowDecoration = () => (
+  <>
+    {["#e05252", "#e8974a", "#e8c34d", "#5aa469", "#4a7fc9", "#7a5ac9"].map((c, i) => (
+      <path key={c} d={`M${6 + i} ${46 + i * 1.05} L${34 - i} ${46 + i * 1.05}`} stroke={c} strokeWidth={1.15} opacity={0.9} />
+    ))}
+    <path d="M5 46 L35 46 L32 43 L8 43 Z" fill="none" stroke="#3d3d3d" strokeWidth={1.8} />
+  </>
+)
+
+const CrystalDecoration = () => (
+  <>
+    {[[9, 44, 20, 47], [20, 47, 31, 44], [9, 44, 15, 50], [31, 44, 25, 50], [15, 50, 25, 50]].map(([x1, y1, x2, y2], i) => (
+      <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke="#ffffff" strokeWidth={0.6} opacity={0.7} />
+    ))}
+    <path d="M11 45.5 L15 44 L13 48 Z" fill="#ffffff" opacity={0.55} />
+  </>
+)
+
+const SweetheartDecoration = () => (
+  <>
+    {[8, 12, 16, 20, 24, 28, 32].map((x) => (
+      <circle key={x} cx={x} cy={41} r={2} fill="#f3c8d6" stroke="#3d3d3d" strokeWidth={1} />
+    ))}
+    {[[13, 47], [27, 47.5]].map(([x, y], i) => (
+      <path
+        key={i}
+        d={`M${x} ${y - 1} C${x - 1.3} ${y - 1.9} ${x - 2} ${y - 0.4} ${x} ${y + 1} C${x + 2} ${y - 0.4} ${x + 1.3} ${y - 1.9} ${x} ${y - 1} Z`}
+        fill="#e0678e"
+        opacity={0.85}
+      />
+    ))}
+  </>
+)
+
+const LaurelDecoration = () => (
+  <>
+    {[-1, 1].map((side) =>
+      Array.from({ length: 4 }, (_, i) => {
+        const x = 20 + side * (2.5 + i * 1.6)
+        const y = 40.5 + i * 0.35
+        return (
+          <ellipse
+            key={`${side}-${i}`}
+            cx={x}
+            cy={y}
+            rx={1.4}
+            ry={0.7}
+            fill="#4a7c3f"
+            stroke="#3d3d3d"
+            strokeWidth={0.5}
+            transform={`rotate(${side * 35} ${x} ${y})`}
+          />
+        )
+      })
+    )}
+    <path d="M18.5 40.5 L18.2 44 L20 43 L21.8 44 L21.5 40.5" fill="#c9394a" stroke="#3d3d3d" strokeWidth={0.6} />
+  </>
+)
+
+const ConstellationDecoration = () => {
+  const pts: [number, number][] = [[13, 46], [18, 44], [24, 45], [28, 48], [16, 49]]
+  return (
+    <>
+      {pts.slice(0, -1).map(([x1, y1], i) => {
+        const [x2, y2] = pts[i + 1]
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke="#8ea8e8" strokeWidth={0.4} opacity={0.7} />
+      })}
+      {pts.map(([x, y], i) => (
+        <circle key={i} cx={x} cy={y} r={i === 1 ? 1.1 : 0.6} fill="#f4e9c1" />
+      ))}
+    </>
+  )
+}
+
+const MosaicDecoration = () => {
+  const colors = ["#e05252", "#4a7fc9", "#e8c34d", "#5aa469", "#7a5ac9"]
+  const tiles: ReactNode[] = []
+  let i = 0
+  for (let y = 45; y <= 49; y += 2) {
+    for (let x = 9; x <= 31; x += 3) {
+      tiles.push(
+        <rect key={`${x}-${y}`} x={x} y={y} width={1.8} height={1.8} fill={colors[i % colors.length]} opacity={0.85} transform={`rotate(45 ${x + 0.9} ${y + 0.9})`} />
+      )
+      i++
+    }
+  }
+  return (
+    <>
+      {tiles}
+      <path d="M5 46 L35 46 L32 43 L8 43 Z" fill="none" stroke="#3d3d3d" strokeWidth={1.8} />
+    </>
+  )
+}
+
+const RoyalDecoration = () => (
+  <>
+    <path
+      d="M7 41 L9.5 43.5 L12 41 L14.5 43.5 L17 41 L19.5 43.5 L20.5 43.5 L23 41 L25.5 43.5 L28 41 L30.5 43.5 L33 41"
+      fill="none"
+      stroke="#d4af37"
+      strokeWidth={1.3}
+      strokeLinejoin="round"
+    />
+    {[[10, 42.3, "#c9394a"], [16, 42.3, "#4a7fc9"], [24, 42.3, "#4a7fc9"], [30, 42.3, "#c9394a"]].map(([x, y, c], i) => (
+      <circle key={i} cx={x as number} cy={y as number} r={0.7} fill={c as string} />
+    ))}
+  </>
+)
+
+const FireworkDecoration = () => {
+  const rays: ReactNode[] = []
+  for (let a = 0; a < 360; a += 30) {
+    const rad = (a * Math.PI) / 180
+    const x1 = 20 + Math.cos(rad) * 2, y1 = 46 + Math.sin(rad) * 2
+    const x2 = 20 + Math.cos(rad) * 5.5, y2 = 46 + Math.sin(rad) * 5.5
+    rays.push(<line key={a} x1={x1} y1={y1} x2={x2} y2={y2} stroke="#f4c542" strokeWidth={0.7} strokeLinecap="round" />)
+  }
+  return (
+    <>
+      {rays}
+      {[[13, 43, "#e05252"], [27, 44, "#4a7fc9"], [16, 48.5, "#5aa469"]].map(([x, y, c], i) => (
+        <circle key={i} cx={x as number} cy={y as number} r={0.6} fill={c as string} />
+      ))}
+    </>
+  )
+}
+
+const SpecialPotDecoration = ({ style }: { style: SpecialPotStyle }) => {
+  switch (style) {
+    case "trophy":
+      return <TrophyDecoration />
+    case "starlight":
+      return <StarlightDecoration />
+    case "rainbow":
+      return <RainbowDecoration />
+    case "crystal":
+      return <CrystalDecoration />
+    case "sweetheart":
+      return <SweetheartDecoration />
+    case "laurel":
+      return <LaurelDecoration />
+    case "constellation":
+      return <ConstellationDecoration />
+    case "mosaic":
+      return <MosaicDecoration />
+    case "royal":
+      return <RoyalDecoration />
+    case "firework":
+      return <FireworkDecoration />
+    default:
+      return null
+  }
+}
+
 export const SeedlingPlant = ({ tier = 0, active, className, variant, showParticles = true, growthPoints = 0 }: { tier?: PlantTier; active: boolean; className?: string; variant?: PlantVariantConfig; showParticles?: boolean; growthPoints?: number }) => {
   const swayControls = useAnimation()
   const leafBounceControls = useAnimation()
@@ -1350,7 +1538,8 @@ export const SeedlingPlant = ({ tier = 0, active, className, variant, showPartic
   const leafColor = active ? (variant?.palette.leaf ?? config.leafColor) : "#d4d4d8"
   const flowerColor = active ? (variant?.palette.flower ?? config.flowerColor) : "#71717a"
   const fruitColor = active ? (variant?.palette.fruit ?? config.fruitColor) : "#71717a"
-  const potColor = active ? (variant?.palette.pot ?? config.potColor) : "#9c8b7e"
+  const specialPot = variant && isSpecialPotStyle(variant.pot) ? variant.pot : null
+  const potColor = active ? (specialPot ? getSpecialPotColor(specialPot) : (variant?.palette.pot ?? config.potColor)) : "#9c8b7e"
   const soilColor = active ? (variant?.palette.soil ?? config.soilColor) : "#6b5b4e"
   const outlineColor = active ? "#3d3d3d" : "#52525b"
   const strokeW = 1.8
@@ -1498,6 +1687,8 @@ export const SeedlingPlant = ({ tier = 0, active, className, variant, showPartic
                   <circle cx="27" cy="44" r="0.5" fill={outlineColor} opacity={0.2} />
                 </>
               )}
+              {/* Special reward pot decoration — admin-granted only, never random */}
+              {active && specialPot && <SpecialPotDecoration style={specialPot} />}
               {/* Cute pot face — a small constant of charm on every species, not tier-gated */}
               {active && (
                 <>

--- a/src/lib/plant-variants.ts
+++ b/src/lib/plant-variants.ts
@@ -200,10 +200,10 @@ export interface PotPaths {
   rim: string
 }
 
-export type PotStyle = "round" | "square" | "tall" | "bowl"
-export const POT_STYLES: PotStyle[] = ["round", "square", "tall", "bowl"]
+export type BasicPotStyle = "round" | "square" | "tall" | "bowl"
+export const POT_STYLES: BasicPotStyle[] = ["round", "square", "tall", "bowl"]
 
-const POT_PATHS: Record<PotStyle, PotPaths> = {
+const POT_PATHS: Record<BasicPotStyle, PotPaths> = {
   round: {
     bottom: "M9 44 C9 50 13 51.5 20 51.5 C27 51.5 31 50 31 44 Z",
     rim: "M7 44 L33 44 L31 41 L9 41 Z",
@@ -220,6 +220,87 @@ const POT_PATHS: Record<PotStyle, PotPaths> = {
     bottom: "M7 46 C7 52 13 52 20 52 C27 52 33 52 33 46 Z",
     rim: "M5 46 L35 46 L32 43 L8 43 Z",
   },
+}
+
+/* ─── Special reward pots ───
+   Exclusive pot skins an admin grants a learner — kept out of POT_STYLES so
+   getPlantVariant's random draw never picks one; only reachable through an
+   explicit override. Each reuses one of the 4 base shapes above but wears
+   its own fixed color instead of the learner's palette, plus a decoration
+   drawn by SpecialPotDecoration in streak-components.tsx. */
+
+export type SpecialPotStyle =
+  | "trophy"
+  | "starlight"
+  | "rainbow"
+  | "crystal"
+  | "sweetheart"
+  | "laurel"
+  | "constellation"
+  | "mosaic"
+  | "royal"
+  | "firework"
+
+export const SPECIAL_POT_STYLES: SpecialPotStyle[] = [
+  "trophy",
+  "starlight",
+  "rainbow",
+  "crystal",
+  "sweetheart",
+  "laurel",
+  "constellation",
+  "mosaic",
+  "royal",
+  "firework",
+]
+
+export const SPECIAL_POT_LABELS: Record<SpecialPotStyle, string> = {
+  trophy: "Golden Trophy",
+  starlight: "Starlight",
+  rainbow: "Rainbow",
+  crystal: "Crystal Facet",
+  sweetheart: "Sweetheart",
+  laurel: "Laurel Medal",
+  constellation: "Constellation",
+  mosaic: "Mosaic",
+  royal: "Royal",
+  firework: "Firework",
+}
+
+const SPECIAL_POT_BASE_SHAPE: Record<SpecialPotStyle, BasicPotStyle> = {
+  trophy: "round",
+  starlight: "tall",
+  rainbow: "bowl",
+  crystal: "square",
+  sweetheart: "round",
+  laurel: "tall",
+  constellation: "square",
+  mosaic: "bowl",
+  royal: "round",
+  firework: "tall",
+}
+
+const SPECIAL_POT_COLORS: Record<SpecialPotStyle, string> = {
+  trophy: "#8a3b3b",
+  starlight: "#1a2340",
+  rainbow: "#f6f1e4",
+  crystal: "#bcdcf0",
+  sweetheart: "#f3c8d6",
+  laurel: "#c77d61",
+  constellation: "#242850",
+  mosaic: "#d9c9a3",
+  royal: "#4b2e6b",
+  firework: "#26262e",
+}
+
+export type PotStyle = BasicPotStyle | SpecialPotStyle
+
+export function isSpecialPotStyle(style: string): style is SpecialPotStyle {
+  return (SPECIAL_POT_STYLES as string[]).includes(style)
+}
+
+export function getSpecialPotColor(style: SpecialPotStyle): string {
+  return SPECIAL_POT_COLORS[style]
 }
 
 /* ─── Leaf Shapes (relative, pointing up-left) ─── */
@@ -354,7 +435,10 @@ export function getPlantVariant(userId: string, overrides?: PlantVariantOverride
 
   return {
     palette: overridePalette ?? hashedPalette,
-    pot: overrides?.pot && (POT_STYLES as string[]).includes(overrides.pot) ? (overrides.pot as PotStyle) : hashedPot,
+    pot:
+      overrides?.pot && ((POT_STYLES as string[]).includes(overrides.pot) || isSpecialPotStyle(overrides.pot))
+        ? (overrides.pot as PotStyle)
+        : hashedPot,
     leaf: overrides?.leaf && (LEAF_STYLES as string[]).includes(overrides.leaf) ? (overrides.leaf as LeafStyle) : hashedLeaf,
     flower:
       overrides?.flower && (FLOWER_TYPES as string[]).includes(overrides.flower)
@@ -375,7 +459,8 @@ export function getAllPalettes(): PlantPalette[] {
 /* ─── Exported utilities ─── */
 
 export function getPotPath(style: PotStyle): PotPaths {
-  return POT_PATHS[style]
+  const baseShape = isSpecialPotStyle(style) ? SPECIAL_POT_BASE_SHAPE[style] : style
+  return POT_PATHS[baseShape]
 }
 
 export function getLeafPath(style: LeafStyle): string {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ten special pot styles, including trophy, starlight, rainbow, crystal, sweetheart, laurel, constellation, mosaic, royal, and firework designs.
  - Special pots now display unique colors, decorations, and corresponding plant appearances.
  - Plant override options are grouped with clear labels, including administrator-only reward pots.
  - The override preview now shows the fully grown plant before saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->