### PR TITLE
Redesign learner dashboard for a compact, scannable layout

### DIFF
--- a/src/components/reflections-dashboard.tsx
+++ b/src/components/reflections-dashboard.tsx
@@ -3,8 +3,7 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { useQueryClient } from "react-query";
 import { motion } from "framer-motion";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { AlertDialog, AlertDialogContent, AlertDialogAction, AlertDialogCancel } from "@/components/ui/alert-dialog";
 import { Plus, BookOpen, CheckCircle } from "lucide-react";
@@ -13,12 +12,10 @@ import { useReflections, type Reflection } from "@/hooks/use-reflections";
 import { useStreakCalculation } from "@/hooks/use-streak-calculation";
 import { reflectionZones, calculateZoneStats, findDominantZone } from "./reflection-zones";
 import { StreakIcon, GrowthBar, ComfortZoneMessage } from "./streak-components";
-import { getMilestoneForStreak, getRandomComfortMessage, getRandomStreakQuote, getNextTierProgress } from "@/lib/streak-milestones";
+import { getNextTierProgress, getMilestoneForStreak, getRandomStreakQuote } from "@/lib/streak-milestones";
 import { getPlantVariant } from "@/lib/plant-variants";
 import { ReflectionsTable } from "./reflections-table";
 import FeedbackForm from "./linear-feedback-form";
-import { ReflectionPreview } from "./reflection-preview";
-import { SubmissionStatusCard } from "./submission-status-card";
 import { AchievementsSection } from "./achievements-section";
 import LearnerGenmateGardenWidget from "./learner-genmate-garden-widget";
 import { FertilizerInventoryButton } from "./fertilizer-inventory-button";
@@ -56,6 +53,20 @@ interface ReflectionsDashboardProps {
   onReflectionSubmit?: () => Promise<void>;
 }
 
+const getGreeting = (hour: number) => {
+  if (hour >= 5 && hour < 12) return "Good morning";
+  if (hour >= 12 && hour < 17) return "Good afternoon";
+  if (hour >= 17 && hour < 21) return "Good evening";
+  return "Good night";
+};
+
+const zoneCount = (zoneStats: ReturnType<typeof calculateZoneStats>, zoneId: string) => {
+  if (zoneId === "comfort") return zoneStats.comfort;
+  if (zoneId === "stretch-enjoying") return zoneStats.stretchEnjoying;
+  if (zoneId === "stretch-overwhelmed") return zoneStats.stretchOverwhelmed;
+  return zoneStats.panic;
+};
+
 export default function ReflectionsDashboard({ userId, initialReflections = [], onReflectionSubmit }: ReflectionsDashboardProps) {
   const { reflections, isLoading: isLoadingReflections, error: reflectionsError, addReflection, refetch } = useReflections(userId, initialReflections);
   const queryClient = useQueryClient();
@@ -63,6 +74,7 @@ export default function ReflectionsDashboard({ userId, initialReflections = [], 
   const [user, setUser] = useState<User | null>(null); // New state for user
   const [isLoadingUser, setIsLoadingUser] = useState(false); // New loading state for user
   const [userError, setUserError] = useState<string | null>(null); // New error state for user
+  const [zoneInfoOpen, setZoneInfoOpen] = useState(false);
 
   const protectedDates = useMemo(() => {
     const dates = (user?.fertilizer_log ?? [])
@@ -75,10 +87,6 @@ export default function ReflectionsDashboard({ userId, initialReflections = [], 
   const tierProgress = useMemo(
     () => getNextTierProgress(streakData.currentStreak, user?.growth_points ?? 0),
     [streakData.currentStreak, user?.growth_points]
-  );
-  const oldTierProgress = useMemo(
-    () => getNextTierProgress(streakData.oldStreak, user?.growth_points ?? 0),
-    [streakData.oldStreak, user?.growth_points]
   );
 
   const plantVariant = useMemo(() => {
@@ -201,40 +209,14 @@ export default function ReflectionsDashboard({ userId, initialReflections = [], 
 
   if (totalIsLoading) {
     return (
-      <div className="container mx-auto py-10 space-y-8">
-        <div className="space-y-4">
-          <div className="h-24 w-full">
-            <motion.div
-              className="h-full w-full bg-gradient-to-r from-amber-100 via-amber-50 to-amber-100 rounded-xl"
-              animate={{
-                backgroundPosition: ["0% 0%", "100% 0%", "0% 0%"],
-              }}
-              transition={{
-                duration: 1.5,
-                repeat: Number.POSITIVE_INFINITY,
-                ease: "linear",
-              }}
-            />
+      <div className="container mx-auto py-6 space-y-4">
+        <div className="h-14 w-full rounded-xl bg-muted/40 animate-pulse" />
+        <div className="grid grid-cols-1 lg:grid-cols-[200px_minmax(0,1fr)] gap-4">
+          <div className="space-y-3">
+            <div className="h-20 rounded-lg bg-muted/40 animate-pulse" />
+            <div className="h-20 rounded-lg bg-muted/40 animate-pulse" />
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            {Array(4)
-              .fill(null)
-              .map((_, i) => (
-                <motion.div
-                  key={i}
-                  className="h-36 bg-gradient-to-r from-amber-100 via-amber-50 to-amber-100 rounded-xl"
-                  animate={{
-                    backgroundPosition: ["0% 0%", "100% 0%", "0% 0%"],
-                  }}
-                  transition={{
-                    duration: 1.5,
-                    repeat: Number.POSITIVE_INFINITY,
-                    ease: "linear",
-                    delay: i * 0.2,
-                  }}
-                />
-              ))}
-          </div>
+          <div className="h-64 rounded-lg bg-muted/40 animate-pulse" />
         </div>
       </div>
     );
@@ -247,7 +229,7 @@ export default function ReflectionsDashboard({ userId, initialReflections = [], 
           <Card className="border-destructive/30 bg-destructive/5">
             <CardContent className="p-8">
               <div className="text-center">
-                <h2 
+                <h2
                   className="text-xl font-semibold mb-2"
                   style={{ fontFamily: "'Playfair Display', Georgia, serif" }}
                 >
@@ -263,555 +245,182 @@ export default function ReflectionsDashboard({ userId, initialReflections = [], 
   }
 
   const zoneStats = calculateZoneStats(reflections);
-  const dominantZoneId = findDominantZone(zoneStats);
-  const currentZone = todaysReflection ? reflectionZones.find((zone) => zone.label === todaysReflection.reflection.barometer) : null;
+  const dominantZone = reflectionZones.find((z) => z.id === findDominantZone(zoneStats));
+  const greeting = getGreeting(new Date().getHours());
+  const milestone = streakData.hasCurrentStreak && streakData.currentStreak > 0 ? getMilestoneForStreak(streakData.currentStreak) : null;
 
   return (
-    <div className="container mx-auto py-10">
-      {/* Hero section - Editorial Style */}
-      <motion.div 
-        initial={{ opacity: 0, y: 20 }} 
-        animate={{ opacity: 1, y: 0 }} 
-        transition={{ duration: 0.6, ease: "easeOut" }} 
-        className="mb-10 relative"
+    <div className="container mx-auto py-6 space-y-5">
+      {/* Hero - the one loud element on the page */}
+      <div
+        className="flex flex-wrap items-center justify-between gap-4 p-5 px-6 border-4 border-foreground bg-primary"
+        style={{ boxShadow: "6px 6px 0 0 hsl(var(--foreground))" }}
       >
-        <div className="absolute inset-0 bg-gradient-to-r from-amber-500/5 via-amber-300/5 to-transparent rounded-2xl -z-10" />
-        <div className="p-8 md:p-10">
-          <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
-            <div className="space-y-3">
-              <div className="flex items-center gap-3 flex-wrap">
-                <motion.h1 
-                  className="text-4xl md:text-5xl font-bold tracking-tight"
-                  initial={{ opacity: 0, x: -20 }} 
-                  animate={{ opacity: 1, x: 0 }} 
-                  transition={{ duration: 0.5, delay: 0.2 }}
-                  style={{ fontFamily: "'Playfair Display', Georgia, serif" }}
-                >
-                  Daily Reflections
-                </motion.h1>
-                <StreakIcon streakData={streakData} variant={plantVariant} growthPoints={user?.growth_points ?? 0} />
-                {user && (
-                  <FertilizerInventoryButton
-                    userId={user._id}
-                    balance={user.fertilizer_balance ?? 0}
-                    eligibleProtectDate={streakData.eligibleProtectDate}
-                    onUsed={refreshPlant}
-                  />
-                )}
-                {user && (
-                  <PlantPalettePicker
-                    userId={user._id}
-                    selected={user.selected_palette}
-                    onSaved={refreshPlant}
-                  />
-                )}
-              </div>
-              <motion.p 
-                className="text-lg text-muted-foreground max-w-xl leading-relaxed"
-                initial={{ opacity: 0 }} 
-                animate={{ opacity: 1 }} 
-                transition={{ duration: 0.5, delay: 0.3 }}
-              >
-                {streakData.hasCurrentStreak && streakData.currentStreak > 0 ? (
-                  (() => {
-                    const milestone = getMilestoneForStreak(streakData.currentStreak);
-                    return milestone ? (
-                      <div className="flex flex-col gap-1">
-                        <span className="text-primary font-semibold">{milestone.emoji} {milestone.message}</span>
-                        <span className="text-sm text-muted-foreground/70 italic">{getRandomStreakQuote()}</span>
-                      </div>
-                    ) : (
-                      <>
-                        You've been reflecting consistently for <span className="text-primary font-semibold">{streakData.currentStreak} day{streakData.currentStreak !== 1 ? "s" : ""}</span>. Keep the momentum going.
-                      </>
-                    );
-                  })()
-                ) : streakData.oldStreak > 0 ? (
-                  <ComfortZoneMessage type="comeback" />
-                ) : (
-                  "Track your learning journey and grow through daily reflection"
-                )}
-              </motion.p>
-
-              <LearnerGenmateGardenWidget />
-            </div>
-            <div className="flex-col sm:flex-row items-stretch sm:items-center gap-3">
-              {hasSubmittedToday ? (
-                <motion.div
-                  initial={{ opacity: 0, scale: 0.95 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  className="relative"
-                >
-                  <div className="absolute -inset-1 rounded-full bg-amber-500/20" style={{ filter: 'blur(8px)' }} />
-                  <Button
-                    size="lg"
-                    className="relative shadow-lg font-medium px-6 py-6 text-base bg-amber-600/80 text-amber-100 cursor-default"
-                    disabled
-                  >
-                    <CheckCircle className="mr-2 h-5 w-5" />
-                    <span>Completed for Today</span>
-                  </Button>
-                </motion.div>
-              ) : (
-                <Dialog open={isDialogOpen} onOpenChange={handleDialogClose}>
-                  <DialogTrigger asChild>
-                    <motion.div
-                      whileHover={{ scale: 1.02 }}
-                      whileTap={{ scale: 0.98 }}
-                    >
-                      <div className="relative">
-                        <div
-                          className="absolute -inset-1 rounded-full"
-                          style={{
-                            background: 'linear-gradient(45deg, #d97706, #f59e0b, #fbbf24, #f59e0b, #d97706)',
-                            filter: 'blur(16px)',
-                            opacity: '0.5',
-                            animation: 'warmGlow 4s ease-in-out infinite',
-                          }}
-                        />
-                        <style>{`
-                          @keyframes warmGlow {
-                            0%, 100% { opacity: 0.4; transform: scale(1); }
-                            50% { opacity: 0.7; transform: scale(1.03); }
-                          }
-                        `}</style>
-                        <Button
-                          size="lg"
-                          className="relative shadow-lg font-medium px-6 py-6 text-base bg-amber-600 hover:bg-amber-700 text-white"
-                          disabled={isSubmitting}
-                        >
-                          {isSubmitting ? (
-                            <motion.div className="absolute inset-0 flex items-center justify-center bg-amber-700 rounded-md overflow-hidden" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-                              <motion.div className="h-5 w-5 rounded-full border-2 border-t-transparent border-white" animate={{ rotate: 360 }} transition={{ duration: 1, repeat: Number.POSITIVE_INFINITY, ease: "linear" }} />
-                            </motion.div>
-                          ) : (
-                            <>
-                              <Plus className="mr-2 h-5 w-5" />
-                              {(() => {
-                                const hour = new Date().getHours();
-                                if (hour >= 5 && hour < 12) {
-                                  return "Add Morning Reflection";
-                                } else if (hour >= 12 && hour < 17) {
-                                  return "Add Afternoon Reflection";
-                                } else if (hour >= 17 && hour < 21) {
-                                  return "Add Evening Reflection";
-                                } else {
-                                  return "Add Night Reflection";
-                                }
-                              })()}
-                            </>
-                          )}
-                        </Button>
-                      </div>
-                    </motion.div>
-                  </DialogTrigger>
-                  <DialogContent className="w-screen h-screen md:w-full md:h-auto sm:max-w-[1000px] max-h-[90vh] overflow-y-auto">
-                    <DialogHeader>
-                      <DialogTitle>Add Daily Reflection</DialogTitle>
-                    </DialogHeader>
-                    <div className="overflow-y-auto">
-                      <FeedbackForm
-                        initialData={formData}
-                        onSubmit={handleSubmit}
-                        onChange={setFormData}
-                        onSuccess={() => {
-                          setFormData(undefined);
-                          setIsDialogOpen(false);
-                        }}
-                        isLoading={isSubmitting}
-                      />
-                    </div>
-                  </DialogContent>
-                </Dialog>
-              )}
-              </div>
-            </div>
+        <div className="flex items-center gap-4 flex-wrap">
+          <div className="rounded-xl bg-card shadow-sm px-4 py-3">
+            <StreakIcon streakData={streakData} variant={plantVariant} growthPoints={user?.growth_points ?? 0} />
           </div>
-        </motion.div>
-
-      {/* Submission Status Card */}
-      <SubmissionStatusCard hasSubmitted={hasSubmittedToday} todaysReflection={todaysReflection} />
-
-      {/* Achievements Section - Editorial Header */}
-      {user && user.badges && user.badges.length > 0 && (
-        <div className="mt-12">
-          <h2 
-            className="text-2xl md:text-3xl font-bold mb-6"
-            style={{ fontFamily: "'Playfair Display', Georgia, serif" }}
-          >
-            Your Achievements
-          </h2>
-          <AchievementsSection badges={user.badges} />
+          <div>
+            <p className="text-xl font-medium text-primary-foreground" style={{ fontFamily: "'Playfair Display', Georgia, serif" }}>
+              {greeting}
+              {user?.first_name ? `, ${user.first_name}` : ""}
+            </p>
+            <div className="text-sm text-primary-foreground/85" style={{ fontFamily: "'Playfair Display', Georgia, serif" }}>
+              {milestone ? (
+                <span className="italic">{milestone.emoji} {milestone.message}</span>
+              ) : streakData.hasCurrentStreak && streakData.currentStreak > 0 ? (
+                <span className="italic">
+                  You've been reflecting consistently for {streakData.currentStreak} day{streakData.currentStreak !== 1 ? "s" : ""}. Keep the momentum going.
+                </span>
+              ) : streakData.oldStreak > 0 ? (
+                <ComfortZoneMessage type="comeback" />
+              ) : (
+                <span className="italic">Track your learning journey and grow through daily reflection</span>
+              )}
+            </div>
+            {milestone && <p className="text-xs text-primary-foreground/70 italic mt-0.5">{getRandomStreakQuote()}</p>}
+          </div>
+          {user && (
+            <FertilizerInventoryButton
+              userId={user._id}
+              balance={user.fertilizer_balance ?? 0}
+              eligibleProtectDate={streakData.eligibleProtectDate}
+              onUsed={refreshPlant}
+            />
+          )}
+          {user && <PlantPalettePicker userId={user._id} selected={user.selected_palette} onSaved={refreshPlant} />}
         </div>
-      )}
 
-      {/* Zone Journey - Editorial Insights */}
-      <div className="mt-12">
-        <div className="flex items-center justify-between mb-6">
-          <h2 
-            className="text-2xl md:text-3xl font-bold"
-            style={{ fontFamily: "'Playfair Display', Georgia, serif" }}
-          >
-            Your Zone Journey
-          </h2>
-          <Dialog>
+        {hasSubmittedToday ? (
+          <span className="inline-flex items-center gap-1.5 text-sm font-medium border-2 border-neutral-900 bg-neutral-900 text-neutral-50 px-4 py-2">
+            <CheckCircle className="h-4 w-4" />
+            Completed today
+          </span>
+        ) : (
+          <Dialog open={isDialogOpen} onOpenChange={handleDialogClose}>
             <DialogTrigger asChild>
-              <Button variant="outline" size="sm" className="gap-2">
-                <BookOpen className="h-4 w-4" />
-                Learn about zones
-              </Button>
+              <button
+                disabled={isSubmitting}
+                className="inline-flex items-center gap-1.5 text-sm font-medium border-2 border-neutral-900 bg-neutral-900 text-neutral-50 hover:opacity-90 disabled:opacity-70 px-4 py-2"
+              >
+                {isSubmitting ? (
+                  <motion.div className="h-4 w-4 rounded-full border-2 border-t-transparent border-neutral-50" animate={{ rotate: 360 }} transition={{ duration: 1, repeat: Number.POSITIVE_INFINITY, ease: "linear" }} />
+                ) : (
+                  <Plus className="h-4 w-4" />
+                )}
+                Add reflection
+              </button>
             </DialogTrigger>
-            <DialogContent className="sm:max-w-[800px] max-h-[80vh] overflow-y-auto">
+            <DialogContent className="w-screen h-screen md:w-full md:h-auto sm:max-w-[1000px] max-h-[90vh] overflow-y-auto">
               <DialogHeader>
-                <DialogTitle>Understanding Learning Zones</DialogTitle>
+                <DialogTitle>Add Daily Reflection</DialogTitle>
               </DialogHeader>
-              <div className="space-y-6 p-6">
-                <img src="/baronzone.png" alt="Learning Barometer Zones" className="w-full rounded-lg shadow-md" />
-                <div className="grid gap-4">
-                  {reflectionZones.map((zone) => (
-                    <motion.div key={zone.id} whileHover={{ scale: 1.02 }} transition={{ type: "spring", stiffness: 300 }}>
-                      <Card className="overflow-hidden">
-                        <CardContent className={`p-4 flex items-center gap-4 ${zone.bgColor} bg-opacity-10`}>
-                          <div className="text-2xl">{zone.emoji}</div>
-                          <div>
-                            <h3 className="font-semibold">{zone.label}</h3>
-                            <p className="text-sm text-muted-foreground">
-                              {zone.id === "comfort" && "You're confident and can work independently"}
-                              {zone.id === "stretch-enjoying" && "You're challenged but growing and learning"}
-                              {zone.id === "stretch-overwhelmed" && "You're finding the challenges difficult"}
-                              {zone.id === "panic" && "You're feeling stuck and need support"}
-                            </p>
-                          </div>
-                        </CardContent>
-                      </Card>
-                    </motion.div>
-                  ))}
-                </div>
+              <div className="overflow-y-auto">
+                <FeedbackForm
+                  initialData={formData}
+                  onSubmit={handleSubmit}
+                  onChange={setFormData}
+                  onSuccess={() => {
+                    setFormData(undefined);
+                    setIsDialogOpen(false);
+                  }}
+                  isLoading={isSubmitting}
+                />
               </div>
             </DialogContent>
           </Dialog>
+        )}
+      </div>
+
+      <LearnerGenmateGardenWidget />
+
+      {user && user.badges && user.badges.length > 0 && <AchievementsSection badges={user.badges} />}
+
+      {/* Stat rail + reflection history */}
+      <div className="grid grid-cols-1 lg:grid-cols-[200px_minmax(0,1fr)] gap-6">
+        <div className="space-y-5">
+          <div>
+            <p className="text-xs text-muted-foreground mb-1">Growth points</p>
+            <p className="text-xl font-semibold mb-2">✨ {user?.growth_points ?? 0}</p>
+            <GrowthBar value={tierProgress.current} max={tierProgress.max} />
+            <p className="text-[11px] text-muted-foreground mt-1">
+              {tierProgress.isMaxTier ? "Max tier 🌟" : `${tierProgress.current}/${tierProgress.max} days to next tier`}
+            </p>
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-xs text-muted-foreground">Zone mix</p>
+              <button
+                type="button"
+                onClick={() => setZoneInfoOpen(true)}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Learn about zones"
+              >
+                <BookOpen className="h-3.5 w-3.5" />
+              </button>
+            </div>
+            {zoneStats.total > 0 ? (
+              <>
+                <div className="flex h-2 overflow-hidden mb-2">
+                  {reflectionZones.map((zone) => {
+                    const count = zoneCount(zoneStats, zone.id);
+                    const percentage = (count / zoneStats.total) * 100;
+                    if (percentage === 0) return null;
+                    return <div key={zone.id} className={zone.bgColor} style={{ width: `${percentage}%` }} title={`${zone.label}: ${count}`} />;
+                  })}
+                </div>
+                <p className="text-xs text-muted-foreground">Mostly {dominantZone?.label.split(" - ")[0].toLowerCase() || "—"}</p>
+              </>
+            ) : (
+              <p className="text-xs text-muted-foreground">No reflections yet</p>
+            )}
+          </div>
+
+          {!streakData.hasCurrentStreak && streakData.oldStreak > 0 && (
+            <div>
+              <ComfortZoneMessage type="comeback" className="text-xs" />
+              {streakData.lastActiveDate && (
+                <p className="text-[11px] text-muted-foreground mt-1">
+                  Last active {streakData.lastActiveDate.toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                </p>
+              )}
+            </div>
+          )}
         </div>
 
-        {/* Progress Bar - Zone Distribution */}
-        {zoneStats.total > 0 && (
-          <motion.div 
-            initial={{ opacity: 0, y: 10 }} 
-            animate={{ opacity: 1, y: 0 }} 
-            className="mb-8"
-          >
-            <div className="flex h-4 rounded-full overflow-hidden">
-              {reflectionZones.map((zone) => {
-                const count = zone.id === "comfort" ? zoneStats.comfort : 
-                              zone.id === "stretch-enjoying" ? zoneStats.stretchEnjoying : 
-                              zone.id === "stretch-overwhelmed" ? zoneStats.stretchOverwhelmed : 
-                              zoneStats.panic;
-                const percentage = (count / zoneStats.total) * 100;
-                if (percentage === 0) return null;
-                return (
-                  <div
-                    key={zone.id}
-                    className={zone.bgColor}
-                    style={{ width: `${percentage}%` }}
-                    title={`${zone.label}: ${count} (${Math.round(percentage)}%)`}
-                  />
-                );
-              })}
-            </div>
-            <div className="flex flex-wrap gap-3 mt-3 justify-center">
-              {reflectionZones.map((zone) => {
-                const count = zone.id === "comfort" ? zoneStats.comfort : 
-                              zone.id === "stretch-enjoying" ? zoneStats.stretchEnjoying : 
-                              zone.id === "stretch-overwhelmed" ? zoneStats.stretchOverwhelmed : 
-                              zoneStats.panic;
-                const percentage = Math.round((count / zoneStats.total) * 100) || 0;
-                return (
-                  <div key={zone.id} className="flex items-center gap-1.5 text-sm">
-                    <span className={zone.bgColor + " w-3 h-3 rounded-full"} />
-                    <span className="text-muted-foreground">{zone.id === "comfort" ? "Comfort" : zone.id === "stretch-enjoying" ? "Stretch+" : zone.id === "stretch-overwhelmed" ? "Stretch-" : "Panic"}</span>
-                    <span className="font-medium">{percentage}%</span>
-                  </div>
-                );
-              })}
-            </div>
-          </motion.div>
-        )}
+        <ReflectionsTable reflections={reflections} isAdmin={false} />
+      </div>
 
-        {/* Insight Cards Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {/* Dominant Zone Card */}
-          {(() => {
-            const dominantZone = reflectionZones.find(z => z.id === dominantZoneId);
-            const dominantCount = dominantZone?.id === "comfort" ? zoneStats.comfort : 
-                                  dominantZone?.id === "stretch-enjoying" ? zoneStats.stretchEnjoying : 
-                                  dominantZone?.id === "stretch-overwhelmed" ? zoneStats.stretchOverwhelmed : 
-                                  zoneStats.panic;
-            const dominantPercentage = Math.round((dominantCount / zoneStats.total) * 100) || 0;
-            
-            return (
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.1 }}
-              >
-                <Card className="h-full border-2 border-amber-500/20 bg-gradient-to-br from-amber-500/5 to-transparent">
-                  <CardHeader className="pb-3">
-                    <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wider" style={{ fontFamily: "'DM Sans', sans-serif" }}>
-                      Most Common Zone
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="pt-0">
-                    <div className="flex items-center gap-4 mb-4">
-                      <span className="text-5xl">{dominantZone?.emoji}</span>
-                      <div>
-                        <div className="text-2xl font-bold" style={{ fontFamily: "'Playfair Display', Georgia, serif" }}>
-                          {dominantZone?.label.split(' - ')[0]}
-                        </div>
-                        <div className="text-amber-600 font-medium">{dominantPercentage}% of time</div>
-                      </div>
+      {/* Zone info dialog */}
+      <Dialog open={zoneInfoOpen} onOpenChange={setZoneInfoOpen}>
+        <DialogContent className="sm:max-w-[800px] max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Understanding Learning Zones</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-6 p-6">
+            <img src="/baronzone.png" alt="Learning Barometer Zones" className="w-full rounded-lg shadow-md" />
+            <div className="grid gap-4">
+              {reflectionZones.map((zone) => (
+                <Card key={zone.id} className="overflow-hidden">
+                  <CardContent className={`p-4 flex items-center gap-4 ${zone.bgColor} bg-opacity-10`}>
+                    <div className="text-2xl">{zone.emoji}</div>
+                    <div>
+                      <h3 className="font-semibold">{zone.label}</h3>
+                      <p className="text-sm text-muted-foreground">
+                        {zone.id === "comfort" && "You're confident and can work independently"}
+                        {zone.id === "stretch-enjoying" && "You're challenged but growing and learning"}
+                        {zone.id === "stretch-overwhelmed" && "You're finding the challenges difficult"}
+                        {zone.id === "panic" && "You're feeling stuck and need support"}
+                      </p>
                     </div>
-                    <div className="h-2 bg-muted rounded-full overflow-hidden">
-                      <motion.div 
-                        className={`h-full ${dominantZone?.bgColor}`}
-                        initial={{ width: 0 }}
-                        animate={{ width: `${dominantPercentage}%` }}
-                        transition={{ delay: 0.3, duration: 0.8 }}
-                      />
-                    </div>
-                    <p className="text-sm text-muted-foreground mt-3">
-                      {dominantCount} out of {zoneStats.total} reflections
-                    </p>
                   </CardContent>
                 </Card>
-              </motion.div>
-            );
-          })()}
-
-          {/* Today's Zone Card */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2 }}
-          >
-            <Card className="h-full border-2 border-amber-500/40 bg-amber-500/5">
-              <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-medium text-amber-700 uppercase tracking-wider flex items-center gap-2" style={{ fontFamily: "'DM Sans', sans-serif" }}>
-                  <span className="w-2 h-2 bg-amber-500 rounded-full animate-pulse" />
-                  Today's Zone
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="pt-0">
-                {currentZone ? (
-                  <>
-                    <div className="flex items-center gap-4 mb-4">
-                      <span className="text-5xl">{currentZone.emoji}</span>
-                      <div>
-                        <div className="text-2xl font-bold" style={{ fontFamily: "'Playfair Display', Georgia, serif" }}>
-                          {currentZone.label.split(' - ')[0]}
-                        </div>
-                        <div className="text-amber-600 text-sm">
-                          {currentZone.id === "comfort" && "You're feeling confident"}
-                          {currentZone.id === "stretch-enjoying" && "You're growing & learning"}
-                          {currentZone.id === "stretch-overwhelmed" && "It's getting challenging"}
-                          {currentZone.id === "panic" && "You need support"}
-                        </div>
-                      </div>
-                    </div>
-                  </>
-                ) : (
-                  <div className="flex items-center gap-4">
-                    <span className="text-4xl">❓</span>
-                    <div>
-                      <div className="text-lg font-medium">No reflection yet</div>
-                      <p className="text-sm text-muted-foreground">Add your reflection to see your zone</p>
-                    </div>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </motion.div>
-
-          {/* Quick Stats Card */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.3 }}
-          >
-            <Card className="h-full">
-              <CardHeader className="pb-3">
-                <CardTitle className="text-sm font-medium text-muted-foreground uppercase tracking-wider" style={{ fontFamily: "'DM Sans', sans-serif" }}>
-                  Quick Stats
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="pt-0 space-y-4">
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">Total Reflections</span>
-                  <span className="font-bold text-lg">{zoneStats.total}</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">Current Streak</span>
-                  <span className="font-bold text-lg flex items-center gap-1">
-                    <span className="text-amber-500">🔥</span>
-                    {streakData.currentStreak}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">Days in Comfort</span>
-                  <span className="font-bold text-lg text-green-600">{zoneStats.comfort}</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-muted-foreground">Days Need Support</span>
-                  <span className="font-bold text-lg text-purple-600">{zoneStats.panic}</span>
-                </div>
-              </CardContent>
-            </Card>
-          </motion.div>
-        </div>
-      </div>
-
-      {/* Today's Reflection - Editorial Card */}
-      {todaysReflection && (
-        <motion.div 
-          initial={{ opacity: 0, y: 20 }} 
-          animate={{ opacity: 1, y: 0 }} 
-          transition={{ duration: 0.5 }} 
-          className="mb-16"
-        >
-          <Card className="overflow-hidden border-2 border-amber-500/20 bg-gradient-to-br from-card to-amber-500/5 mt-4">
-            <CardHeader className="pb-2">
-              <CardTitle 
-                className="flex items-center gap-3 text-xl"
-                style={{ fontFamily: "'Playfair Display', Georgia, serif" }}
-              >
-                <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-amber-500/20 text-amber-600">
-                  ✦
-                </span>
-                Today's Reflection
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="p-6">
-              <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
-                <div className="space-y-4">
-                  <motion.p 
-                    className="text-xl font-medium flex items-center gap-3" 
-                    initial={{ opacity: 0, x: -10 }} 
-                    animate={{ opacity: 1, x: 0 }} 
-                    transition={{ duration: 0.3, delay: 0.2 }}
-                  >
-                    <span className="text-3xl">{currentZone?.emoji}</span>
-                    <span>You're in the <span className="text-primary font-semibold">{currentZone?.label}</span> zone</span>
-                  </motion.p>
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-3">
-                      <GrowthBar value={tierProgress.current} max={tierProgress.max} />
-                      <div className="flex items-center gap-1">
-                        <span className="tabular-nums font-medium">{streakData.currentStreak} day streak</span>
-                        <span className="text-xs text-muted-foreground tabular-nums">
-                          {tierProgress.isMaxTier ? "· max tier 🌟" : `· ${tierProgress.current}/${tierProgress.max} to next tier`}
-                        </span>
-                      </div>
-                    </div>
-                    {user && (user.growth_points ?? 0) > 0 && (
-                      <div className="flex items-center gap-3">
-                        <GrowthBar
-                          variant="growth"
-                          value={(user.growth_points ?? 0) % 50 || 50}
-                          max={50}
-                        />
-                        <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
-                          ✨ {user.growth_points} growth points
-                        </span>
-                      </div>
-                    )}
-                    {streakData.currentStreak >= 5 && (
-                      <motion.div 
-                        initial={{ opacity: 0, height: 0 }} 
-                        animate={{ opacity: 1, height: "auto" }} 
-                        transition={{ duration: 0.3 }} 
-                        className="text-sm text-amber-700 font-medium dark:text-amber-400"
-                      >
-                        {getRandomComfortMessage("gentle")}
-                      </motion.div>
-                    )}
-                  </div>
-                </div>
-                <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} className="w-full md:w-auto">
-                  <ReflectionPreview reflection={todaysReflection} />
-                </motion.div>
-              </div>
-            </CardContent>
-          </Card>
-        </motion.div>
-      )}
-
-      {/* Streak History Card */}
-      {!streakData.hasCurrentStreak && streakData.oldStreak > 0 && (
-        <motion.div 
-          initial={{ opacity: 0, y: 20 }} 
-          animate={{ opacity: 1, y: 0 }} 
-          transition={{ duration: 0.5, delay: 0.2 }} 
-          className="mb-10"
-        >
-          <Card className="overflow-hidden border border-border/50">
-            <CardHeader className="pb-4">
-              <CardTitle 
-                className="text-xl flex items-center gap-2"
-                style={{ fontFamily: "'Playfair Display', Georgia, serif" }}
-              >
-                <span className="text-muted-foreground">Previous Streak</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="p-6">
-              <div className="flex flex-col md:flex-row items-center justify-between gap-6">
-                <div className="space-y-2">
-                  <p className="text-lg font-medium">
-                    <ComfortZoneMessage type="comeback" />
-                  </p>
-                  {streakData.lastActiveDate && (
-                    <p className="text-sm text-muted-foreground">
-                      Last active: {streakData.lastActiveDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
-                    </p>
-                  )}
-                  <div className="mt-4">
-                    <Button 
-                      variant="outline" 
-                      onClick={() => !hasSubmittedToday && setIsDialogOpen(true)} 
-                      disabled={hasSubmittedToday} 
-                      className="border-amber-500/30 hover:bg-amber-500/10"
-                    >
-                      <Plus className="mr-2 h-4 w-4" />
-                      {hasSubmittedToday ? "Added for Today" : "Start New Streak"}
-                    </Button>
-                  </div>
-                </div>
-                <div className="w-full md:w-1/3">
-                  <div className="relative h-3 bg-muted rounded-full overflow-hidden">
-                    <div
-                      className="absolute top-0 left-0 h-full bg-gradient-to-r from-amber-500 to-amber-400"
-                      style={{ width: `${oldTierProgress.isMaxTier ? 100 : (oldTierProgress.current / oldTierProgress.max) * 100}%` }}
-                    />
-                  </div>
-                  <div className="flex justify-between mt-2 text-xs text-muted-foreground">
-                    <span>0</span>
-                    <span>{Math.round(oldTierProgress.max / 2)}</span>
-                    <span>{oldTierProgress.max} days</span>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </motion.div>
-      )}
-
-      {/* Reflections Table - Editorial Header */}
-      <div className="mt-12">
-        <h2 
-          className="text-2xl md:text-3xl font-bold mb-6"
-          style={{ fontFamily: "'Playfair Display', Georgia, serif" }}
-        >
-          Your Reflection History
-        </h2>
-        <ReflectionsTable reflections={reflections} todaysReflection={todaysReflection} isAdmin={false} />
-      </div>
+              ))}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       {/* Warning Dialog */}
       <AlertDialog open={showCloseWarning} onOpenChange={setShowCloseWarning}>

--- a/src/components/reflections-table.test.tsx
+++ b/src/components/reflections-table.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { ReflectionsTable } from './reflections-table';
 import type { Reflection } from '@/hooks/use-reflections';
 
 describe('ReflectionsTable', () => {
-  it('renders reflection cards and expands to show session details', () => {
+  it('renders reflection rows and opens a dialog with session details on click', () => {
     const mockReflections: Reflection[] = [
       {
         _id: '1',
@@ -29,14 +29,17 @@ describe('ReflectionsTable', () => {
 
     render(<ReflectionsTable reflections={mockReflections} />);
 
-    // The zone label is visible on the collapsed card header.
-    expect(screen.getByText('Comfort Zone')).toBeInTheDocument();
+    // The zone label and a one-line preview are visible directly on the timeline row.
+    expect(screen.getByText(/Comfort Zone/)).toBeInTheDocument();
+    expect(screen.getByText('Learning hooks · Good communication')).toBeInTheDocument();
 
-    // Session details are only rendered once the card is expanded.
-    expect(screen.queryByText('Learning hooks')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { expanded: false }));
+    // Full detail (both happy/improve fields) is only rendered once the row is clicked, opening the detail dialog.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText(/Comfort Zone/).closest('[role="button"]')!);
 
-    expect(screen.getByText('Learning hooks')).toBeInTheDocument();
-    expect(screen.getByText('Good communication')).toBeInTheDocument();
+    const dialog = within(screen.getByRole('dialog'));
+    expect(dialog.getByText('State management')).toBeInTheDocument();
+    expect(dialog.getByText('Good communication')).toBeInTheDocument();
+    expect(dialog.getByText('More focus')).toBeInTheDocument();
   });
 });

--- a/src/components/reflections-table.tsx
+++ b/src/components/reflections-table.tsx
@@ -5,11 +5,10 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Card, CardContent } from "@/components/ui/card";
-import { Search, ChevronDown, ChevronUp, MessageSquareText, X } from "lucide-react";
+import { Search, MessageSquareText, ChevronRight, X } from "lucide-react";
 import type { Reflection } from "@/hooks/use-reflections";
 import { reflectionZones } from "./reflection-zones";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
 interface ReflectionsTableProps {
   reflections: Reflection[];
@@ -21,11 +20,9 @@ interface ReflectionsTableProps {
 export const ReflectionsTable = ({ reflections, isAdmin = false }: ReflectionsTableProps) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [timeFilter, setTimeFilter] = useState("all");
-  const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set());
-  const [singleExpandMode, setSingleExpandMode] = useState(false);
+  const [openReflection, setOpenReflection] = useState<Reflection | null>(null);
 
-  const getCardId = (reflection: Reflection, index: number) => 
-    reflection._id ? `${reflection._id}-${index}` : `unknown-${index}`;
+  const getRowId = (reflection: Reflection, index: number) => (reflection._id ? `${reflection._id}-${index}` : `unknown-${index}`);
 
   const filteredReflections = useMemo(() => {
     let filtered = [...reflections];
@@ -112,36 +109,32 @@ export const ReflectionsTable = ({ reflections, isAdmin = false }: ReflectionsTa
     }
   };
 
-  const toggleCard = (id: string) => {
-    setExpandedCards((prev) => {
-      const next = new Set(prev);
-      if (singleExpandMode) {
-        next.clear();
-      }
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
+  const getZone = (reflection: Reflection) => {
+    const barometerValue = reflection.reflection.barometer || "";
+    return reflectionZones.find(
+      (z) => z.label.toLowerCase() === barometerValue.toLowerCase() || z.aliases?.some((alias) => alias.toLowerCase() === barometerValue.toLowerCase()),
+    );
   };
 
-  const expandAll = () => {
-    setExpandedCards(new Set(filteredReflections.map((r, i) => getCardId(r, i))));
+  const isSameDay = (dateString: string) => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const date = new Date(dateString);
+    date.setHours(0, 0, 0, 0);
+    return date.getTime() === today.getTime();
   };
 
-  const collapseAll = () => {
-    setExpandedCards(new Set());
+  const getPreviewLine = (reflection: Reflection) => {
+    const tech = reflection.reflection.tech_sessions.happy || reflection.reflection.tech_sessions.improve;
+    const nonTech = reflection.reflection.non_tech_sessions.happy || reflection.reflection.non_tech_sessions.improve;
+    return [tech, nonTech].filter(Boolean).join(" · ") || "—";
   };
-
-  const isAllExpanded = filteredReflections.length > 0 && filteredReflections.every((r, i) => expandedCards.has(getCardId(r, i)));
 
   return (
-    <div className="space-y-4">
-      {/* Stats Row */}
-      <div className="flex items-center gap-3 flex-wrap">
-        <span className="text-sm text-muted-foreground">
+    <div className="space-y-3">
+      {/* Stats + Search & Filters Row */}
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-sm text-muted-foreground whitespace-nowrap">
           {filteredReflections.length} {filteredReflections.length === 1 ? "reflection" : "reflections"}
         </span>
         <div className="flex gap-1">
@@ -149,26 +142,20 @@ export const ReflectionsTable = ({ reflections, isAdmin = false }: ReflectionsTa
             const count = zoneStats[zone.id] || 0;
             if (count === 0) return null;
             return (
-              <span
-                key={zone.id}
-                className="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground"
-              >
+              <span key={zone.id} className="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground">
                 {zone.emoji} {count}
               </span>
             );
           })}
         </div>
-      </div>
 
-      {/* Search & Filters Row */}
-      <div className="flex flex-col sm:flex-row gap-3">
-        <div className="relative flex-1 max-w-sm">
+        <div className="relative flex-1 min-w-[160px] max-w-sm">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
             placeholder="Search reflections..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-9 pr-9 h-9"
+            className="pl-9 pr-9 h-8"
           />
           {searchQuery && (
             <button
@@ -179,46 +166,18 @@ export const ReflectionsTable = ({ reflections, isAdmin = false }: ReflectionsTa
             </button>
           )}
         </div>
-        
-        <div className="flex items-center gap-2">
-          <Tabs value={timeFilter} onValueChange={setTimeFilter}>
-            <TabsList className="h-9">
-              <TabsTrigger value="all" className="text-xs px-3">All</TabsTrigger>
-              <TabsTrigger value="month" className="text-xs px-3">Month</TabsTrigger>
-              <TabsTrigger value="week" className="text-xs px-3">Week</TabsTrigger>
-              <TabsTrigger value="today" className="text-xs px-3">Today</TabsTrigger>
-            </TabsList>
-          </Tabs>
-          
-          {isAllExpanded ? (
-            <Button variant="outline" size="sm" onClick={collapseAll} className="h-9 gap-1">
-              <ChevronUp className="h-3 w-3" />
-              Collapse
-            </Button>
-          ) : (
-            <Button variant="outline" size="sm" onClick={expandAll} className="h-9 gap-1">
-              <ChevronDown className="h-3 w-3" />
-              Expand
-            </Button>
-          )}
-          
-          <Button
-            variant={singleExpandMode ? "default" : "outline"}
-            size="sm"
-            onClick={() => setSingleExpandMode(!singleExpandMode)}
-            className="h-9 gap-1"
-            title="Single expand mode - only one card open at a time"
-          >
-            <svg className="h-3 w-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <rect x="3" y="3" width="18" height="18" rx="2" />
-              <line x1="9" y1="3" x2="9" y2="21" />
-            </svg>
-            1-at-a-time
-          </Button>
-        </div>
+
+        <Tabs value={timeFilter} onValueChange={setTimeFilter}>
+          <TabsList className="h-8">
+            <TabsTrigger value="all" className="text-xs px-3">All</TabsTrigger>
+            <TabsTrigger value="month" className="text-xs px-3">Month</TabsTrigger>
+            <TabsTrigger value="week" className="text-xs px-3">Week</TabsTrigger>
+            <TabsTrigger value="today" className="text-xs px-3">Today</TabsTrigger>
+          </TabsList>
+        </Tabs>
       </div>
 
-      {/* Cards List */}
+      {/* Table */}
       {filteredReflections.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-center border-2 border-dashed rounded-lg">
           <p className="text-muted-foreground mb-2">No reflections found</p>
@@ -234,152 +193,107 @@ export const ReflectionsTable = ({ reflections, isAdmin = false }: ReflectionsTa
           </Button>
         </div>
       ) : (
-        <div className="space-y-2">
-          {filteredReflections.map((reflection, index) => {
-            const barometerValue = reflection?.reflection?.barometer || "";
-            const zone = reflectionZones.find(
-              (z) =>
-                z.label.toLowerCase() === barometerValue.toLowerCase() ||
-                z.aliases?.some((alias) => alias.toLowerCase() === barometerValue.toLowerCase()),
-            );
-            const cardId = getCardId(reflection, index);
-            const isExpanded = expandedCards.has(cardId);
+        <div className="rounded-md border bg-card divide-y overflow-hidden">
+          <AnimatePresence>
+            {filteredReflections.map((reflection, index) => {
+              const rowDate = reflection.day || reflection.date;
+              const isToday = isSameDay(rowDate);
+              const zone = getZone(reflection);
 
-            const zoneBgColor = zone?.bgColor || "bg-muted";
-            const bgOpacityClass = zone ? "bg-opacity-20" : "";
-
-            const isToday = (() => {
-              const today = new Date();
-              today.setHours(0, 0, 0, 0);
-              const reflectionDate = new Date(reflection.day || reflection.date);
-              reflectionDate.setHours(0, 0, 0, 0);
-              return reflectionDate.getTime() === today.getTime();
-            })();
-
-            return (
-              <motion.div
-                key={cardId}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ duration: 0.2, delay: index * 0.03 }}
-              >
-                <Card className={`overflow-hidden ${zoneBgColor} ${bgOpacityClass} transition-all duration-200 hover:shadow-md ${isToday ? 'ring-2 ring-amber-500/50' : ''}`}>
-                  {/* Card Header - Always Visible */}
-                  <div
-                    className="flex items-center justify-between p-3 cursor-pointer hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
-                    onClick={() => toggleCard(cardId)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        toggleCard(cardId);
-                      }
-                    }}
-                    role="button"
-                    tabIndex={0}
-                    aria-expanded={isExpanded}
-                  >
-                    <span className="text-sm font-medium flex items-center gap-2">
-                      {formatDate(reflection.day || reflection.date)}
-                      {isToday && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-700 dark:text-amber-300 font-semibold">
-                          TODAY
-                        </span>
-                      )}
-                    </span>
-                    
-                    <div className="flex items-center gap-2">
-                      {zone && (
-                        <span className="text-sm font-medium">
-                          {zone.label}
-                        </span>
-                      )}
-                      <span className="text-lg">
-                        {zone?.emoji || "❓"}
-                      </span>
-                      <motion.div
-                        animate={{ rotate: isExpanded ? 180 : 0 }}
-                        transition={{ duration: 0.2 }}
-                      >
-                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                      </motion.div>
-                    </div>
-                  </div>
-
-                  {/* Card Content - Expandable */}
-                  <AnimatePresence>
-                    {isExpanded && (
-                      <motion.div
-                        initial={{ height: 0 }}
-                        animate={{ height: "auto" }}
-                        exit={{ height: 0 }}
-                        transition={{ duration: 0.2 }}
-                      >
-                        <CardContent className="pt-0 pb-3 px-3">
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-3 border-t border-black/10">
-                            {/* Tech Session */}
-                            <div>
-                              <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-                                Tech Session
-                              </h4>
-                              <div className="space-y-2 text-sm">
-                                <div>
-                                  <span className="text-green-700 text-xs font-medium">Went well</span>
-                                  <p>{reflection.reflection.tech_sessions.happy || "—"}</p>
-                                </div>
-                                <div>
-                                  <span className="text-amber-700 text-xs font-medium">To improve</span>
-                                  <p>{reflection.reflection.tech_sessions.improve || "—"}</p>
-                                </div>
-                              </div>
-                            </div>
-
-                            {/* Non-Tech Session */}
-                            <div>
-                              <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-                                Non-Tech Session
-                              </h4>
-                              <div className="space-y-2 text-sm">
-                                <div>
-                                  <span className="text-green-700 text-xs font-medium">Went well</span>
-                                  <p>{reflection.reflection.non_tech_sessions.happy || "—"}</p>
-                                </div>
-                                <div>
-                                  <span className="text-amber-700 text-xs font-medium">To improve</span>
-                                  <p>{reflection.reflection.non_tech_sessions.improve || "—"}</p>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-
-                          {/* Admin Feedback */}
-                          {!isAdmin && reflection.admin_feedback && (
-                            <div className="mt-3 pt-3 border-t border-black/10">
-                              <Dialog>
-                                <DialogTrigger asChild>
-                                  <Button variant="outline" size="sm" className="w-full text-xs bg-white/50">
-                                    <MessageSquareText className="h-3 w-3 mr-1" />
-                                    View Admin Feedback
-                                  </Button>
-                                </DialogTrigger>
-                                <DialogContent>
-                                  <DialogHeader>
-                                    <DialogTitle>Admin Feedback</DialogTitle>
-                                  </DialogHeader>
-                                  <p className="py-2 whitespace-pre-wrap text-sm">{reflection.admin_feedback}</p>
-                                </DialogContent>
-                              </Dialog>
-                            </div>
-                          )}
-                        </CardContent>
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
-                </Card>
-              </motion.div>
-            );
-          })}
+              return (
+                <motion.div
+                  key={getRowId(reflection, index)}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.15, delay: index * 0.02 }}
+                  onClick={() => setOpenReflection(reflection)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setOpenReflection(reflection);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  className={`flex items-center gap-3 py-2 px-3 cursor-pointer transition-colors hover:bg-muted/50 ${isToday ? "bg-amber-500/5" : ""}`}
+                >
+                  <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${zone?.bgColor || "bg-muted-foreground"}`} />
+                  <span className="text-sm text-muted-foreground w-[92px] shrink-0 whitespace-nowrap">
+                    {formatDate(rowDate)}
+                    {isToday && <span className="ml-1.5 text-[10px] font-semibold text-amber-600">TODAY</span>}
+                  </span>
+                  <span className="text-sm font-medium w-[150px] shrink-0 truncate">
+                    {zone?.emoji || "❓"} {(zone?.label || reflection.reflection.barometer || "—").split(" - ")[0]}
+                  </span>
+                  <span className="text-sm text-muted-foreground flex-1 min-w-0 truncate">{getPreviewLine(reflection)}</span>
+                  {!isAdmin && reflection.admin_feedback && (
+                    <MessageSquareText className="h-3.5 w-3.5 text-amber-600 shrink-0" aria-label="Has admin feedback" />
+                  )}
+                  <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" aria-hidden="true" />
+                </motion.div>
+              );
+            })}
+          </AnimatePresence>
         </div>
       )}
+
+      {/* Detail Dialog */}
+      <Dialog open={!!openReflection} onOpenChange={(open) => !open && setOpenReflection(null)}>
+        <DialogContent className="sm:max-w-[600px]">
+          {openReflection && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2 text-base">
+                  {formatDate(openReflection.day || openReflection.date)}
+                  <span className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
+                    <span className="text-lg">{getZone(openReflection)?.emoji || "❓"}</span>
+                    {getZone(openReflection)?.label || openReflection.reflection.barometer || "—"}
+                  </span>
+                </DialogTitle>
+              </DialogHeader>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2">
+                <div>
+                  <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1.5">Tech Session</h4>
+                  <div className="space-y-2 text-sm">
+                    <div>
+                      <span className="text-green-700 text-xs font-medium">Went well</span>
+                      <p>{openReflection.reflection.tech_sessions.happy || "—"}</p>
+                    </div>
+                    <div>
+                      <span className="text-amber-700 text-xs font-medium">To improve</span>
+                      <p>{openReflection.reflection.tech_sessions.improve || "—"}</p>
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1.5">Non-Tech Session</h4>
+                  <div className="space-y-2 text-sm">
+                    <div>
+                      <span className="text-green-700 text-xs font-medium">Went well</span>
+                      <p>{openReflection.reflection.non_tech_sessions.happy || "—"}</p>
+                    </div>
+                    <div>
+                      <span className="text-amber-700 text-xs font-medium">To improve</span>
+                      <p>{openReflection.reflection.non_tech_sessions.improve || "—"}</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {!isAdmin && openReflection.admin_feedback && (
+                <div className="mt-1 pt-3 border-t border-black/10">
+                  <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1.5 flex items-center gap-1">
+                    <MessageSquareText className="h-3.5 w-3.5" /> Admin Feedback
+                  </h4>
+                  <p className="text-sm whitespace-pre-wrap">{openReflection.admin_feedback}</p>
+                </div>
+              )}
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Replaces the large gradient hero, 3-card zone-journey grid, and accordion-style reflection history with a slim hero (streak plant, milestone copy, quick-add reflection), a compact stat rail (growth points, zone mix), and a one-line-per-day reflection timeline.
- Clicking a timeline row opens a detail dialog with the full tech/non-tech happy + improve breakdown, so no data is hidden behind the compact preview.
- Fixes a flex/grid `min-width` bug where long reflection text (e.g. Thai-language entries) could overflow past the row and off the page instead of truncating with an ellipsis.
- Switches the hero's accent colors to the app's `--primary`/`--foreground` design tokens instead of hardcoded Tailwind amber shades, so it renders correctly in both light and dark mode.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run` (32/32 passing, including an updated `reflections-table.test.tsx` for the new row → dialog interaction)
- [ ] Manual click-through on `/learner` (couldn't verify live in this session — no login credentials available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a compact reflections dashboard with greetings, streak milestones, plant and fertilizer controls, growth progress, zone statistics, achievements, and reflection history.
  * Added a zone-information dialog for viewing additional zone details.
  * Updated reflection history with a streamlined timeline showing dates, zones, previews, and feedback indicators.
  * Select or keyboard-activate a reflection to view its complete session details.
  * Added responsive search and filtering for reflection history.

* **Improvements**
  * Simplified loading visuals for faster, clearer dashboard feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->