### PR TITLE
feat: fertilize a genmate's plant from the garden

### DIFF
--- a/src/application/services/fertilizerService.ts
+++ b/src/application/services/fertilizerService.ts
@@ -17,6 +17,10 @@ export const fertilizerService = {
   async feed(userId: string, quantity = 1): Promise<void> {
     await api.post<FertilizerActionResponse>(`/users/${userId}/fertilizer/feed`, { quantity });
   },
+
+  async gift(userId: string, quantity = 1): Promise<void> {
+    await api.post<FertilizerActionResponse>(`/users/${userId}/fertilizer/gift`, { quantity });
+  },
 };
 
 export default fertilizerService;

--- a/src/components/genmate-garden.test.tsx
+++ b/src/components/genmate-garden.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GenmateGarden } from "./genmate-garden";
@@ -12,6 +12,22 @@ vi.mock("@/lib/api", () => ({
 vi.mock("@/AuthContext", () => ({
   useAuth: () => ({ userId: "current-user" }),
 }));
+
+const refetchUserData = vi.fn();
+let mockBalance = 3;
+vi.mock("@/UserDataContext", () => ({
+  useUserData: () => ({
+    userData: { fertilizer_balance: mockBalance },
+    refetchUserData,
+  }),
+}));
+
+vi.mock("@/application/services/fertilizerService", () => ({
+  fertilizerService: { gift: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import { fertilizerService } from "@/application/services/fertilizerService";
+const mockedGift = vi.mocked(fertilizerService.gift);
 
 import { api } from "@/lib/api";
 const mockedGet = vi.mocked(api.get);
@@ -88,6 +104,8 @@ function renderGarden() {
 describe("GenmateGarden", () => {
   beforeEach(() => {
     mockedGet.mockReset();
+    mockedGift.mockClear();
+    mockBalance = 3;
   });
 
   afterEach(() => {
@@ -160,5 +178,39 @@ describe("GenmateGarden", () => {
     expect(await screen.findByText("Alice Smith")).toBeInTheDocument();
     expect(screen.getByText("Reflections")).toBeInTheDocument();
     expect(screen.getByText("Next milestone")).toBeInTheDocument();
+  });
+
+  it("gifts one fertilizer to a genmate and hides the button on your own tile", async () => {
+    const { alice, bob, carol } = makeUsers();
+    const me = { ...bob, _id: "current-user", first_name: "Me", last_name: "Myself" };
+    mockedGet.mockResolvedValue({
+      data: { data: { users: [alice, bob, carol, me] } },
+    } as never);
+
+    renderGarden();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Alice/ }));
+    const fertilize = await screen.findByRole("button", { name: /Fertilize/ });
+    fireEvent.click(fertilize);
+    await waitFor(() => expect(mockedGift).toHaveBeenCalledWith("user-1", 1));
+
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    fireEvent.click(await screen.findByRole("button", { name: /Me/ }));
+    expect(await screen.findByText("Me Myself")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Fertilize/ })).toBeNull();
+  });
+
+  it("disables the fertilize button when you have no fertilizer", async () => {
+    mockBalance = 0;
+    const { alice, bob, carol } = makeUsers();
+    mockedGet.mockResolvedValue({
+      data: { data: { users: [alice, bob, carol] } },
+    } as never);
+
+    renderGarden();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Alice/ }));
+    expect(await screen.findByRole("button", { name: /Fertilize/ })).toBeDisabled();
+    expect(screen.getByText("You have no fertilizer left.")).toBeInTheDocument();
   });
 });

--- a/src/components/genmate-garden.tsx
+++ b/src/components/genmate-garden.tsx
@@ -37,6 +37,8 @@ import type { Reflection } from "@/hooks/use-reflections";
 import type { ProfileReaction } from "@/domain/types";
 import { addPlantReaction } from "@/application/services/userService";
 import { useAuth } from "@/AuthContext";
+import { useUserData } from "@/UserDataContext";
+import { fertilizerService } from "@/application/services/fertilizerService";
 import { SeedlingPlant } from "@/components/streak-components";
 import { getUserAvatarUrl, getAvatarFallback } from "@/lib/avatar";
 import { formatDate } from "@/lib/utils";
@@ -263,6 +265,25 @@ export function PlantTile({ member }: { member: GardenMember }) {
     }
   );
 
+  const { userData, refetchUserData } = useUserData();
+  const myBalance = userData?.fertilizer_balance ?? 0;
+  const isSelf = user._id === currentUserId;
+
+  const giftMutation = useMutation(() => fertilizerService.gift(user._id, 1), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(["learnerGenmateGarden"]);
+      queryClient.invalidateQueries(["adminGenmateGarden"]);
+      void refetchUserData();
+      toast.success(`Sent fertilizer to ${user.first_name ?? "your genmate"} 🌱`);
+    },
+    onError: (error: unknown) => {
+      const message =
+        (error as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        "Couldn't send fertilizer. Please try again.";
+      toast.error(message);
+    },
+  });
+
   const handleCheer = (event: MouseEvent, reaction: string) => {
     event.preventDefault();
     cheerMutation.mutate({ type: "emoji", value: reaction });
@@ -414,6 +435,22 @@ export function PlantTile({ member }: { member: GardenMember }) {
                 )}
               </div>
             </div>
+            {!isSelf && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full rounded-full"
+                disabled={giftMutation.isLoading || myBalance < 1}
+                onClick={() => giftMutation.mutate()}
+              >
+                🧪 Fertilize · 1 → +10 🌱
+              </Button>
+            )}
+            {!isSelf && myBalance < 1 && (
+              <p className="text-center text-xs text-muted-foreground">
+                You have no fertilizer left.
+              </p>
+            )}
           </div>
         </div>
       </PopoverContent>

--- a/src/domain/types/fertilizer.ts
+++ b/src/domain/types/fertilizer.ts
@@ -1,6 +1,6 @@
 export interface FertilizerLogEntry {
   _id?: string;
-  kind: "grant" | "protect" | "feed";
+  kind: "grant" | "protect" | "feed" | "gift" | "gifted";
   amount: number;
   relatedDate?: string;
   note?: string;

--- a/src/pages/LearnerGenmateGardenPage.test.tsx
+++ b/src/pages/LearnerGenmateGardenPage.test.tsx
@@ -14,6 +14,17 @@ vi.mock("@/AuthContext", () => ({
   useAuth: () => ({ userId: "current-user" }),
 }));
 
+vi.mock("@/UserDataContext", () => ({
+  useUserData: () => ({
+    userData: { fertilizer_balance: 3 },
+    refetchUserData: vi.fn(),
+  }),
+}));
+
+vi.mock("@/application/services/fertilizerService", () => ({
+  fertilizerService: { gift: vi.fn().mockResolvedValue(undefined) },
+}));
+
 import { getMyGenmateGarden } from "@/lib/api";
 const mockedGetGarden = vi.mocked(getMyGenmateGarden);
 


### PR DESCRIPTION
Adds a Fertilize button to the garden PlantTile popover: one click spends one of your fertilizer and adds 10 growth points to that genmate's plant. Hidden on your own tile, disabled when your balance is zero.

Balance comes from UserDataContext, so no props are threaded through the tile. On success both garden query keys are invalidated and the current user is refetched so the balance updates in place.