### PR TITLE
feat: rescue a genmate's missed day with your fertilizer

### DIFF
--- a/src/application/services/fertilizerService.ts
+++ b/src/application/services/fertilizerService.ts
@@ -21,6 +21,10 @@ export const fertilizerService = {
   async gift(userId: string, quantity = 1): Promise<void> {
     await api.post<FertilizerActionResponse>(`/users/${userId}/fertilizer/gift`, { quantity });
   },
+
+  async rescue(userId: string, date: string): Promise<void> {
+    await api.post<FertilizerActionResponse>(`/users/${userId}/fertilizer/rescue`, { date });
+  },
 };
 
 export default fertilizerService;

--- a/src/components/genmate-garden.test.tsx
+++ b/src/components/genmate-garden.test.tsx
@@ -23,11 +23,28 @@ vi.mock("@/UserDataContext", () => ({
 }));
 
 vi.mock("@/application/services/fertilizerService", () => ({
-  fertilizerService: { gift: vi.fn().mockResolvedValue(undefined) },
+  fertilizerService: {
+    gift: vi.fn().mockResolvedValue(undefined),
+    rescue: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 import { fertilizerService } from "@/application/services/fertilizerService";
+import { isValidWorkday } from "@/utils/date-utils";
 const mockedGift = vi.mocked(fertilizerService.gift);
+const mockedRescue = vi.mocked(fertilizerService.rescue);
+
+// Walk back from today collecting `count` workdays (skipping weekends), oldest first.
+function lastNWorkdays(count: number): Date[] {
+  const days: Date[] = [];
+  const cursor = new Date();
+  cursor.setHours(0, 0, 0, 0);
+  while (days.length < count) {
+    if (isValidWorkday(cursor)) days.unshift(new Date(cursor));
+    cursor.setDate(cursor.getDate() - 1);
+  }
+  return days;
+}
 
 import { api } from "@/lib/api";
 const mockedGet = vi.mocked(api.get);
@@ -105,6 +122,7 @@ describe("GenmateGarden", () => {
   beforeEach(() => {
     mockedGet.mockReset();
     mockedGift.mockClear();
+    mockedRescue.mockClear();
     mockBalance = 3;
   });
 
@@ -198,6 +216,48 @@ describe("GenmateGarden", () => {
     fireEvent.click(await screen.findByRole("button", { name: /Me/ }));
     expect(await screen.findByText("Me Myself")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Fertilize/ })).toBeNull();
+  });
+
+  it("rescues a genmate's missed workday", async () => {
+    const workdays = lastNWorkdays(5);
+    const gapDay = workdays[3];
+    const gappy = {
+      _id: "user-gap",
+      first_name: "Gap",
+      last_name: "Person",
+      cohort_number: 12,
+      genmate_group: "Garden Alpha",
+      reflections: workdays
+        .filter((d) => d.getTime() !== gapDay.getTime())
+        .map((d) => makeReflection(localDayString(d))),
+    };
+    const { bob } = makeUsers();
+    mockedGet.mockResolvedValue({
+      data: { data: { users: [gappy, bob] } },
+    } as never);
+
+    renderGarden();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Gap/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /Rescue/ }));
+    await waitFor(() =>
+      expect(mockedRescue).toHaveBeenCalledWith("user-gap", localDayString(gapDay))
+    );
+  });
+
+  it("offers no rescue when the genmate has no missed day", async () => {
+    const { alice, bob, carol } = makeUsers();
+    mockedGet.mockResolvedValue({
+      data: { data: { users: [alice, bob, carol] } },
+    } as never);
+
+    renderGarden();
+
+    // Bob has never reflected, so there is no gap day to protect.
+    fireEvent.click(await screen.findByRole("button", { name: /Bob/ }));
+    expect(
+      await screen.findByRole("button", { name: /No missed day to rescue/ })
+    ).toBeDisabled();
   });
 
   it("disables the fertilize button when you have no fertilizer", async () => {

--- a/src/components/genmate-garden.tsx
+++ b/src/components/genmate-garden.tsx
@@ -284,6 +284,28 @@ export function PlantTile({ member }: { member: GardenMember }) {
     },
   });
 
+  const rescueDate = streakData.eligibleProtectDate;
+
+  const rescueMutation = useMutation(
+    () => fertilizerService.rescue(user._id, rescueDate as string),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["learnerGenmateGarden"]);
+        queryClient.invalidateQueries(["adminGenmateGarden"]);
+        void refetchUserData();
+        toast.success(
+          `Rescued ${rescueDate} for ${user.first_name ?? "your genmate"} — their streak is safe!`
+        );
+      },
+      onError: (error: unknown) => {
+        const message =
+          (error as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+          "Couldn't rescue that day. Please try again.";
+        toast.error(message);
+      },
+    }
+  );
+
   const handleCheer = (event: MouseEvent, reaction: string) => {
     event.preventDefault();
     cheerMutation.mutate({ type: "emoji", value: reaction });
@@ -444,6 +466,19 @@ export function PlantTile({ member }: { member: GardenMember }) {
                 onClick={() => giftMutation.mutate()}
               >
                 🧪 Fertilize · 1 → +10 🌱
+              </Button>
+            )}
+            {!isSelf && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full rounded-full"
+                disabled={rescueMutation.isLoading || myBalance < 1 || !rescueDate}
+                onClick={() => rescueMutation.mutate()}
+              >
+                {rescueDate
+                  ? `🛡️ Rescue ${rescueDate} · costs you 1`
+                  : "🛡️ No missed day to rescue"}
               </Button>
             )}
             {!isSelf && myBalance < 1 && (

--- a/src/domain/types/fertilizer.ts
+++ b/src/domain/types/fertilizer.ts
@@ -1,6 +1,6 @@
 export interface FertilizerLogEntry {
   _id?: string;
-  kind: "grant" | "protect" | "feed" | "gift" | "gifted";
+  kind: "grant" | "protect" | "feed" | "gift" | "gifted" | "rescue";
   amount: number;
   relatedDate?: string;
   note?: string;


### PR DESCRIPTION
Adds a second peer action beside Fertilize: spend one of your own fertilizer to protect a genmate's missed workday so their streak survives. The date is their eligible gap day, already computed for every garden tile, so there is no picker; the button disables when they have no gap or you have no stock.

Backed by POST /users/:id/fertilizer/rescue, which writes the same kind:"protect" log entry the self-protect flow writes, so streak math and the already-protected guard behave identically no matter who paid.