### PR TITLE
feat: add admin-only history page for audit log

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import { StudentAttendance } from "./components/student-attendance";
 import { LeaveRequestsTable } from "./components/leave-requests-table";
 import { StudentAttendanceDetail } from "./pages/student-attendance-detail";
 import { AdminNotificationManager } from "./components/admin-notification-manager";
+import AdminHistoryPage from "./pages/admin-history-page";
 
 function AppContent() {
   const { isAuthenticated, error } = useAuth();
@@ -117,6 +118,7 @@ function AppContent() {
             <Route path="attendance/student/:id" element={<StudentAttendanceDetail />} />
             <Route path="leave-requests" element={<LeaveRequestsTable />} />
             <Route path="notifications" element={<AdminNotificationManager />} />
+            <Route path="history" element={<AdminHistoryPage />} />
           </Route>
 
           <Route path="/learner" element={<LearnerLayout />}>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -30,6 +30,7 @@ export default function Page({ children }: { children: React.ReactNode }) {
           'table': 'All Reflections',
           'users': 'User Management',
           'weekly-summary': 'Weekly Summary',
+          'history': 'History',
         };
         
         const pageName = pageNames[pathSegments[1]] || pathSegments[1];

--- a/src/application/services/historyService.ts
+++ b/src/application/services/historyService.ts
@@ -1,0 +1,26 @@
+import { api } from "../../infrastructure/api";
+import type { HistoryQuery, HistoryPage } from "../../domain/types/history";
+
+interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T;
+}
+
+export const historyService = {
+  async getHistory(params: HistoryQuery = {}): Promise<HistoryPage> {
+    const searchParams = new URLSearchParams();
+    if (params.page) searchParams.set("page", String(params.page));
+    if (params.limit) searchParams.set("limit", String(params.limit));
+    if (params.role) searchParams.set("role", params.role);
+    if (params.cohort) searchParams.set("cohort", String(params.cohort));
+    if (params.user_id) searchParams.set("user_id", params.user_id);
+    if (params.method) searchParams.set("method", params.method);
+    if (params.q) searchParams.set("q", params.q);
+
+    const response = await api.get<ApiResponse<HistoryPage>>(`/admin/history?${searchParams.toString()}`);
+    return response.data.data;
+  },
+};
+
+export default historyService;

--- a/src/application/services/index.ts
+++ b/src/application/services/index.ts
@@ -8,3 +8,4 @@ export { fertilizerService, default as fertilizerServiceDefault } from "./fertil
 export { boardService, default as boardServiceDefault } from "./boardService";
 export { stampService, default as stampServiceDefault } from "./stampService";
 export { notificationService, default as notificationServiceDefault } from "./notificationService";
+export { historyService, default as historyServiceDefault } from "./historyService";

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Bell,
   Sprout,
   Stamp,
+  History,
 } from "lucide-react";
 import { motion } from "framer-motion";
 import { Badge } from "@/components/ui/badge";
@@ -99,6 +100,11 @@ const navigationConfig: Record<UserRole, NavItem[]> = {
           title: "Notifications",
           url: "/admin/notifications",
           icon: Bell,
+        },
+        {
+          title: "History",
+          url: "/admin/history",
+          icon: History,
         },
         {
           title: "Tools",

--- a/src/domain/types/history.ts
+++ b/src/domain/types/history.ts
@@ -1,0 +1,30 @@
+export interface AuditLogEntry {
+  id: string;
+  actor_id: string;
+  actor_name: string;
+  actor_role: string;
+  cohort: number;
+  method: string;
+  path: string;
+  route: string;
+  status: number;
+  ip_address: string;
+  createdAt: string;
+}
+
+export interface HistoryQuery {
+  page?: number;
+  limit?: number;
+  role?: string;
+  cohort?: number;
+  user_id?: string;
+  method?: string;
+  q?: string;
+}
+
+export interface HistoryPage {
+  logs: AuditLogEntry[];
+  total: number;
+  page: number;
+  limit: number;
+}

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -4,3 +4,4 @@ export * from "./reflection";
 export * from "./attendance";
 export * from "./badge";
 export * from "./fertilizer";
+export * from "./history";

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,6 +11,7 @@ export {
   fertilizerService,
   boardService,
   stampService,
+  historyService,
 } from "../application/services";
 
 export { awardBadge } from "../application/services/badgeService";

--- a/src/pages/admin-history-page.tsx
+++ b/src/pages/admin-history-page.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "react-query";
+import { format } from "date-fns";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@/components/ui/pagination";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { LoadingRow } from "@/components/loading-row";
+import { historyService } from "@/lib/api";
+import type { HistoryQuery } from "@/domain/types";
+
+const LIMIT = 50;
+
+const STATUS_COLOR = (status: number) => {
+  if (status >= 500) return "text-destructive";
+  if (status >= 400) return "text-yellow-600 dark:text-yellow-400";
+  return "text-muted-foreground";
+};
+
+export default function AdminHistoryPage() {
+  const [page, setPage] = useState(1);
+  const [role, setRole] = useState<string>("all");
+  const [method, setMethod] = useState<string>("all");
+  const [search, setSearch] = useState("");
+
+  const filters: HistoryQuery = {
+    page,
+    limit: LIMIT,
+    role: role === "all" ? undefined : role,
+    method: method === "all" ? undefined : method,
+    q: search.trim() || undefined,
+  };
+
+  const { data, isLoading } = useQuery(
+    ["history", filters],
+    () => historyService.getHistory(filters),
+    { keepPreviousData: true }
+  );
+
+  const logs = data?.logs ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / LIMIT));
+
+  const updateFilter = (setter: (v: string) => void) => (value: string) => {
+    setter(value);
+    setPage(1);
+  };
+
+  return (
+    <div className="py-4">
+      <div className="flex justify-between items-center mb-6 flex-wrap gap-4">
+        <Badge variant="outline" className="text-sm">
+          {total} events
+        </Badge>
+        <div className="flex items-center gap-2 flex-wrap">
+          <Input
+            placeholder="Search path…"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
+            className="w-56"
+          />
+          <Select value={role} onValueChange={updateFilter(setRole)}>
+            <SelectTrigger className="w-36">
+              <SelectValue placeholder="All Roles" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Roles</SelectItem>
+              <SelectItem value="admin">Admin</SelectItem>
+              <SelectItem value="learner">Learner</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={method} onValueChange={updateFilter(setMethod)}>
+            <SelectTrigger className="w-36">
+              <SelectValue placeholder="All Methods" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Methods</SelectItem>
+              <SelectItem value="POST">POST</SelectItem>
+              <SelectItem value="PUT">PUT</SelectItem>
+              <SelectItem value="PATCH">PATCH</SelectItem>
+              <SelectItem value="DELETE">DELETE</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[160px]">Time</TableHead>
+              <TableHead className="w-[180px]">Actor</TableHead>
+              <TableHead className="w-[100px]">Role</TableHead>
+              <TableHead className="w-[90px]">Method</TableHead>
+              <TableHead>Path</TableHead>
+              <TableHead className="w-[80px] text-right">Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              [...Array(8)].map((_, i) => <LoadingRow key={i} />)
+            ) : logs.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                  No activity recorded yet.
+                </TableCell>
+              </TableRow>
+            ) : (
+              logs.map((log) => (
+                <TableRow key={log.id}>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {format(new Date(log.createdAt), "MMM d, HH:mm:ss")}
+                  </TableCell>
+                  <TableCell>{log.actor_name}</TableCell>
+                  <TableCell className="capitalize">{log.actor_role}</TableCell>
+                  <TableCell className="font-mono text-xs">{log.method}</TableCell>
+                  <TableCell className="font-mono text-xs break-all">{log.path}</TableCell>
+                  <TableCell className={`text-right font-mono text-xs ${STATUS_COLOR(log.status)}`}>
+                    {log.status}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <Pagination className="mt-6">
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              onClick={() => setPage((p) => Math.max(p - 1, 1))}
+              aria-disabled={page === 1}
+              className={page === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"}
+            />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink className="cursor-default min-w-[4rem] text-center">
+              {page} / {totalPages}
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext
+              onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
+              aria-disabled={page === totalPages}
+              className={page === totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}


### PR DESCRIPTION
Admins had no visibility into who did what across the platform. Adds an admin-only History page listing recent mutating actions (actor, role, method, path, status) backed by the new /admin/history endpoint.