### PR TITLE
feat: 3D genmate farm — real geometry, cohort-wide field, admin view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,9 @@
         "@radix-ui/react-tabs": "^1.1.2",
         "@radix-ui/react-toast": "^1.2.5",
         "@radix-ui/react-tooltip": "^1.1.7",
+        "@react-three/drei": "^9.122.0",
+        "@react-three/fiber": "^8.18.0",
+        "@react-three/postprocessing": "^2.19.1",
         "@types/js-cookie": "^3.0.6",
         "axios": "^1.7.9",
         "canvas-confetti": "^1.9.4",
@@ -49,6 +52,7 @@
         "sonner": "^1.7.1",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "three": "^0.173.0",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -59,6 +63,7 @@
         "@types/node": "^22.10.2",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
+        "@types/three": "^0.173.0",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.17.0",
@@ -1431,6 +1436,24 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -2995,6 +3018,23 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@react-spring/three": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.7.5.tgz",
+      "integrity": "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=6.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "three": ">=0.126"
+      }
+    },
     "node_modules/@react-spring/types": {
       "version": "9.7.5",
       "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
@@ -3013,6 +3053,150 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "9.122.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.122.0.tgz",
+      "integrity": "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@react-spring/three": "~9.7.5",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^2.9.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "react-composer": "^5.0.3",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.7.8",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.0",
+        "tunnel-rat": "^0.1.2",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^8",
+        "react": "^18",
+        "react-dom": "^18",
+        "three": ">=0.137"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/postprocessing": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/@react-three/postprocessing/-/postprocessing-2.19.1.tgz",
+      "integrity": "sha512-7P25LOSToH/I6b3UipNK17IIFlX4FDUmWcaomfwu82+CzhXTOz8Fcc1ZXEZ7vFA/5Fr/2peNlXgXZJvoa+aCdA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "maath": "^0.6.0",
+        "n8ao": "^1.6.6",
+        "postprocessing": "^6.32.1",
+        "three-stdlib": "^2.23.4"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^8.0",
+        "react": "^18.0",
+        "three": ">= 0.138.0"
+      }
+    },
+    "node_modules/@react-three/postprocessing/node_modules/maath": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.6.0.tgz",
+      "integrity": "sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.144.0",
+        "three": ">=0.144.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3487,6 +3671,12 @@
         }
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -3630,6 +3820,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -3657,6 +3853,12 @@
         "undici-types": "~6.20.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
@@ -3666,7 +3868,6 @@
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3681,11 +3882,46 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true
+    },
+    "node_modules/@types/three": {
+      "version": "0.173.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.173.0.tgz",
+      "integrity": "sha512-KtNjfI/CRB6JVKIVeZM1R3GYDX2wkoV2itNcQu2j4d7qkhjGOuB+s2oF6jl9mztycDLGMtrAnJQYxInC8Bb20A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.18.2",
@@ -3897,6 +4133,24 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.4.tgz",
@@ -4001,6 +4255,12 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.72.tgz",
+      "integrity": "sha512-0cF7RFM2edNoiIS1ODJp0/Gzv4/xSXhwoR0YCza+OWpJWtn4wmo9DvK91aLlH9+uUnwIriP7ZiC3WitmyhuzBw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -4218,11 +4478,30 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -4315,6 +4594,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4342,6 +4645,15 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
+      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4590,6 +4902,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -4855,6 +5185,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -4891,6 +5230,12 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5296,6 +5641,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -5597,6 +5948,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5674,6 +6031,12 @@
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "dev": true
     },
+    "node_modules/hls.js": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.7.2.tgz",
+      "integrity": "sha512-CW/pPvSOFIRsosbwxrYaE9ERmpTo5fbTqL7wCvuCFlqW1Bmb1K5fXsY7yiH95rmlr4rVuA7UXHbM/cIXQ6AXwg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -5728,6 +6091,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5736,6 +6119,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -5868,10 +6257,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -6035,6 +6451,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -6117,6 +6542,16 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6158,6 +6593,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -6329,6 +6779,16 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/n8ao": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/n8ao/-/n8ao-1.10.3.tgz",
+      "integrity": "sha512-JFRk4WgUAUWO2KdJTqmBT02dP9kG7rE2oQbBy64E9+YwQ3d96KB9QBanqNy/NnYUfUTYU6Z/5OS5t/yLey7+6Q==",
+      "license": "ISC",
+      "peerDependencies": {
+        "postprocessing": ">=6.30.0",
+        "three": ">=0.137"
       }
     },
     "node_modules/nano-time": {
@@ -6745,6 +7205,21 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/postprocessing": {
+      "version": "6.39.4",
+      "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.39.4.tgz",
+      "integrity": "sha512-oAS/PjAbc/xT3OzjUrGsorJ4J064XwhVD2t0OwKLP/E8QwDMUJ0oOv6ZI1SYMtLchv4g0ySEx+JcLy92+48vlA==",
+      "license": "Zlib",
+      "peerDependencies": {
+        "three": ">= 0.168.0 < 0.186.0"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6802,6 +7277,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6864,6 +7349,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-composer": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.3.tgz",
+      "integrity": "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-custom-roulette": {
@@ -6943,6 +7440,31 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/react-refresh": {
@@ -7099,6 +7621,21 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -7180,7 +7717,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7442,6 +7978,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -7621,6 +8183,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -7711,6 +8282,45 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.173.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.173.0.tgz",
+      "integrity": "sha512-AUwVmViIEUgBwxJJ7stnF0NkPpZxx1aZ6WiAbQ/Qq61h6I9UR4grXtZDmO8mnlaNORhHnIBlXJ1uBxILEKuVyw==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.8.tgz",
+      "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==",
+      "deprecated": "Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.151.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.11.tgz",
+      "integrity": "sha512-3JyEFWGjFn7zHmoa9+zG1BmW7X2okcmAB+0Cnu9UFbVs/jCBnl2A8o065ZlXiw145K3eBM3uLuzrYXC0RK7eDg==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -7849,6 +8459,36 @@
         "node": ">=20"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.5",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.5.tgz",
+      "integrity": "sha512-Ry3jRhic9pzcY4JduSvRRyDmVOSqEW19gT4vtK+aCiPNVcDlmkxvGG0YbFd36RTDq1wExOupXnvNF/j1oiHHDA==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.5",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.5",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.5.tgz",
+      "integrity": "sha512-WsePbcX8RtfidRfsxK1eCZCjF81ZDzAKHH/evLs0hdV2wpoCb0vArGZHdzdOJrSS3k4zfdtbKDaBh8+phkrYnw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -7870,6 +8510,43 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8037,10 +8714,28 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
@@ -8310,6 +9005,17 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.0",
@@ -8651,6 +9357,35 @@
       "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.15.tgz",
+      "integrity": "sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.5",
     "@radix-ui/react-tooltip": "^1.1.7",
+    "@react-three/drei": "^9.122.0",
+    "@react-three/fiber": "^8.18.0",
+    "@react-three/postprocessing": "^2.19.1",
     "@types/js-cookie": "^3.0.6",
     "axios": "^1.7.9",
     "canvas-confetti": "^1.9.4",
@@ -55,6 +58,7 @@
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "three": "^0.173.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {
@@ -65,6 +69,7 @@
     "@types/node": "^22.10.2",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
+    "@types/three": "^0.173.0",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.17.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import UserProfilePage from "./pages/UserProfilePage";
 import LearnerDirectoryPage from "./pages/LearnerDirectoryPage";
 import MyProfileWrapper from "./pages/MyProfileWrapper";
 import LearnerGenmateGardenPage from "./pages/LearnerGenmateGardenPage";
+import CohortGenmateGardenPage from "./pages/CohortGenmateGardenPage";
 import TalkBoardPage from "./pages/talk-board-page";
 import PostPage from "./pages/PostPage";
 import StampBoardPage from "./pages/stamp-board-page";
@@ -26,6 +27,7 @@ import SpinWheelPage from "./pages/SpinWheelPage";
 import WeeklySummaryPage from "./pages/weekly-summary-page";
 import { AdminDashboard } from "./pages/admin/AdminDashboard";
 import { GenmateGardenPage } from "./pages/admin/GenmateGardenPage";
+import { AdminCohortFarmPage } from "./pages/admin/AdminCohortFarmPage";
 import { AdminLayout } from "./routes/layouts/AdminLayout";
 import { AuthedPageLayout } from "./routes/layouts/AuthedPageLayout";
 import { LearnerLayout } from "./routes/layouts/LearnerLayout";
@@ -105,6 +107,7 @@ function AppContent() {
             <Route path="table/:id" element={<UserReflectionsPage />} />
             <Route path="users" element={<AdminUsersPage />} />
             <Route path="garden" element={<GenmateGardenPage />} />
+            <Route path="cohort-farm" element={<AdminCohortFarmPage />} />
             <Route path="weekly-summary" element={<WeeklySummaryPage />} />
             <Route path="attendance" element={<AttendanceShell />}>
               <Route index element={<Navigate to="register" replace />} />
@@ -127,6 +130,7 @@ function AppContent() {
             <Route path="directory" element={<LearnerDirectoryPage />} />
             <Route path="my-profile" element={<MyProfileWrapper />} />
             <Route path="garden" element={<LearnerGenmateGardenPage />} />
+            <Route path="cohort-garden" element={<CohortGenmateGardenPage />} />
           </Route>
 
           <Route

--- a/src/application/services/userService.ts
+++ b/src/application/services/userService.ts
@@ -6,6 +6,8 @@ import type {
   UserData,
   GenmateGardenMember,
   GenmateGardenResponse,
+  CohortGardenGroup,
+  CohortGardenResponse,
   SocialLinks,
 } from "../../domain/types";
 
@@ -18,6 +20,11 @@ export const userService = {
   async getMyGenmateGarden(): Promise<GenmateGardenMember[]> {
     const response = await api.get<GenmateGardenResponse>("/users/genmate-garden");
     return response.data.data.users;
+  },
+
+  async getCohortGarden(cohortNumber: number): Promise<CohortGardenGroup[]> {
+    const response = await api.get<CohortGardenResponse>(`/cohorts/${cohortNumber}/garden`);
+    return response.data.data.groups;
   },
 
   async getAllUsers(): Promise<User[]> {
@@ -69,6 +76,7 @@ export const userService = {
 export const getAllUsers = userService.getAllUsers;
 export const getCohort = userService.getUsersByCohort;
 export const getMyGenmateGarden = userService.getMyGenmateGarden;
+export const getCohortGarden = userService.getCohortGarden;
 export const addProfileComment = userService.addProfileComment;
 export const addProfileReaction = userService.addProfileReaction;
 export const addPlantReaction = userService.addPlantReaction;

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -73,6 +73,11 @@ const navigationConfig: Record<UserRole, NavItem[]> = {
           icon: Sprout,
         },
         {
+          title: "Cohort Field",
+          url: "/admin/cohort-farm",
+          icon: Sprout,
+        },
+        {
           title: "Learner Directory",
           url: "/learner/directory",
           icon: Users,

--- a/src/components/farm/FarmEffects.tsx
+++ b/src/components/farm/FarmEffects.tsx
@@ -1,0 +1,21 @@
+import { EffectComposer, Bloom, HueSaturation } from "@react-three/postprocessing";
+
+/**
+ * Bloom picks up the Aura's additive, `toneMapped={false}` glow — it was
+ * built for this without a real bloom pass, so lighting it up here is mostly
+ * free visual gain.
+ *
+ * A DepthOfField pass was tried here too, but on this field's orthographic
+ * camera it has no perspective falloff to key off — it blurred uniformly
+ * across the whole scene instead of a tasteful tilt-shift accent, so it's
+ * been dropped rather than re-tuned blind (this session's browser automation
+ * can't render actual WebGL frames to check parameter changes against).
+ */
+export function FarmEffects() {
+  return (
+    <EffectComposer>
+      <Bloom luminanceThreshold={0.9} intensity={0.5} mipmapBlur />
+      <HueSaturation saturation={0.08} />
+    </EffectComposer>
+  );
+}

--- a/src/components/farm/GenmateField.tsx
+++ b/src/components/farm/GenmateField.tsx
@@ -1,0 +1,541 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { Html, ContactShadows } from "@react-three/drei";
+import * as THREE from "three";
+import type { PlantPalette, PlantSpecies } from "@/lib/plant-variants";
+import { getPlantTierConfig, type PlantTier } from "@/lib/streak-milestones";
+import { PlantMesh, PartMesh } from "@/components/farm/PlantMesh";
+import { FarmEffects } from "@/components/farm/FarmEffects";
+import { GrassField } from "@/components/farm/GrassField";
+import { SkyDome } from "@/components/farm/SkyDome";
+import { getPartTexture, getToonGradientMap } from "@/lib/farm-textures";
+import { terrainHeightAt, TERRAIN_MARGIN } from "@/lib/farm-terrain";
+import { useFarmPlantParts, useFarmPlantHeight } from "@/hooks/use-farm-plant";
+import { buildFenceParts, buildGroundProps, buildBackgroundTrees } from "@/lib/farm-decorations";
+import {
+  computeTileSize,
+  tilePositionsForCount,
+  tileCenter,
+  leastOccludingRotationStep,
+  gridDimensionsForCount,
+  auraSpecForTier,
+  buildParticleDefs,
+  isRisingParticle,
+  FIELD_PITCH,
+  FIELD_YAW_BASE,
+  type ParticleDef,
+} from "@/lib/farm-layout";
+
+export interface GenmateFieldMember {
+  id: string;
+  name: string;
+  species: PlantSpecies;
+  tier: PlantTier;
+  palette: PlantPalette;
+  active: boolean;
+  displayStreakDays: number;
+}
+
+interface GenmateFieldProps {
+  members: GenmateFieldMember[];
+  onContextLost?: () => void;
+}
+
+// Shared between the key light and the visible sun in the sky dome, so the
+// glowing disc up there is actually where the light comes from instead of a
+// decoration floating in an unrelated direction.
+const SUN_DIRECTION: [number, number, number] = [6, 10, 4];
+
+const ZOOM_MIN = 0.6;
+const ZOOM_MAX = 2.5;
+const ZOOM_SENSITIVITY = 0.0015;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * One connected block of land, an FFT-style fixed-angle camera with 90°
+ * rotation steps, real 3D plants standing together — the genmate-farm map's
+ * tickets 02/09/03/04/05/10/11, resolved as a spike
+ * (https://claude.ai/code/artifact/c78b6a76-bbc7-445a-8efd-f327213f1a6b) and
+ * ported here to real @react-three/fiber primitives rather than the spike's
+ * hand-rolled software renderer.
+ */
+export function GenmateField({ members, onContextLost }: GenmateFieldProps) {
+  const tileSize = useMemo(() => computeTileSize(), []);
+  // Sized to the actual headcount — a genmate group stays the tuned 3×3, a
+  // whole cohort field grows instead of silently dropping anyone past 9.
+  const { cols, rows } = useMemo(() => gridDimensionsForCount(members.length), [members.length]);
+  const positions = useMemo(() => tilePositionsForCount(members.length, cols, rows), [members.length, cols, rows]);
+  const [rotationStep, setRotationStep] = useState(() => leastOccludingRotationStep(positions, tileSize, cols, rows));
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [zoom, setZoom] = useState(1);
+
+  const landW = cols * tileSize;
+  const landD = rows * tileSize;
+  const fieldDiag = Math.hypot(landW, landD);
+
+  const emptyTileWorldPositions = useMemo(() => {
+    const occupied = new Set(positions.map((p) => `${p.col},${p.row}`));
+    const empties: Array<{ x: number; z: number }> = [];
+    for (let col = 0; col < cols; col++) {
+      for (let row = 0; row < rows; row++) {
+        if (occupied.has(`${col},${row}`)) continue;
+        empties.push(tileCenter(col, row, tileSize, cols, rows));
+      }
+    }
+    return empties;
+  }, [positions, tileSize, cols, rows]);
+  const groundProps = useMemo(() => buildGroundProps(emptyTileWorldPositions), [emptyTileWorldPositions]);
+  const fenceParts = useMemo(() => buildFenceParts(landW, landD), [landW, landD]);
+  const backgroundTreeParts = useMemo(() => buildBackgroundTrees(landW, landD), [landW, landD]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="relative aspect-[4/3] w-full overflow-hidden rounded-xl border border-border bg-gradient-to-b from-sky-200 to-emerald-50 dark:from-slate-800 dark:to-slate-900">
+        <Canvas
+          shadows
+          gl={{ toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 0.95 }}
+          onCreated={({ gl }) => {
+            gl.domElement.addEventListener("webglcontextlost", (e) => {
+              e.preventDefault();
+              onContextLost?.();
+            });
+            // Native listener with `{ passive: false }`, not React's `onWheel`
+            // (which React makes passive by default and silently ignores
+            // `preventDefault()` on) — needed so zooming the field doesn't
+            // also scroll the page. Trackpad pinch arrives as the same
+            // `wheel` event (browser-synthesized with `ctrlKey: true`), so
+            // one handler covers both scroll-to-zoom and pinch-to-zoom.
+            gl.domElement.addEventListener(
+              "wheel",
+              (e) => {
+                e.preventDefault();
+                setZoom((z) => clamp(z - e.deltaY * ZOOM_SENSITIVITY, ZOOM_MIN, ZOOM_MAX));
+              },
+              { passive: false }
+            );
+          }}
+        >
+          <FieldCamera fieldDiag={fieldDiag} rotationStep={rotationStep} zoom={zoom} />
+          <SkyDome radius={fieldDiag * 1.8} sunDirection={SUN_DIRECTION} />
+          <ambientLight intensity={0.35} />
+          <directionalLight position={SUN_DIRECTION} intensity={0.9} castShadow />
+          <directionalLight position={[-5, 6, -3]} intensity={0.3} color="#cfe4ff" />
+          <directionalLight position={[0, 4, -8]} intensity={0.28} color="#fff8e6" />
+          <Ground landW={landW} landD={landD} />
+          <GrassField landW={landW} landD={landD} />
+          <ContactShadows position={[0, 0.01, 0]} opacity={0.4} blur={2} far={fieldDiag} />
+          {fenceParts.map((part, i) => (
+            <PartMesh key={`fence-${i}`} part={part} />
+          ))}
+          {groundProps.map((part, i) => (
+            <PartMesh key={`prop-${i}`} part={part} />
+          ))}
+          {backgroundTreeParts.map((part, i) => (
+            <PartMesh key={`tree-${i}`} part={part} />
+          ))}
+          <Butterflies count={5} spread={Math.min(landW, landD) * 0.4} />
+          <FarmEffects />
+          {members.map((member, i) => {
+            const pos = positions[i];
+            if (!pos) return null;
+            const center = tileCenter(pos.col, pos.row, tileSize, cols, rows);
+            return (
+              <MemberOnTile
+                key={member.id}
+                member={member}
+                worldX={center.x}
+                worldZ={center.z}
+                isHovered={hoveredId === member.id}
+                onHoverChange={(hovered) => setHoveredId(hovered ? member.id : null)}
+              />
+            );
+          })}
+        </Canvas>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setRotationStep((s) => (s + 3) % 4)}
+          className="rounded-md border border-border bg-muted px-3 py-1.5 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+        >
+          ⟲ Rotate
+        </button>
+        <button
+          type="button"
+          onClick={() => setRotationStep((s) => (s + 1) % 4)}
+          className="rounded-md border border-border bg-muted px-3 py-1.5 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+        >
+          ⟳ Rotate
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function FieldCamera({ fieldDiag, rotationStep, zoom }: { fieldDiag: number; rotationStep: number; zoom: number }) {
+  const { size, set, camera: previousCamera } = useThree();
+  const camRef = useRef<THREE.OrthographicCamera>(null);
+  const yaw = FIELD_YAW_BASE + rotationStep * (Math.PI / 2);
+  const distance = fieldDiag * 1.4;
+  const camX = distance * Math.sin(yaw) * Math.cos(FIELD_PITCH);
+  const camZ = distance * Math.cos(yaw) * Math.cos(FIELD_PITCH);
+  const camY = distance * Math.sin(FIELD_PITCH);
+
+  // Explicit world-unit frustum bounds, sized from the actual field diagonal —
+  // not `zoom` against an assumed default frustum, so the framing is exact
+  // regardless of drei/r3f version defaults.
+  const halfHeight = fieldDiag * 0.42;
+  const halfWidth = halfHeight * (size.width / size.height);
+
+  useEffect(() => {
+    if (!camRef.current) return;
+    set({ camera: camRef.current });
+    return () => set({ camera: previousCamera });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // three.js never recomputes a camera's projection matrix on its own — a
+  // frustum edge or `near`/`far` change only takes effect after an explicit
+  // `updateProjectionMatrix()` call. Passing left/right/top/bottom as JSX
+  // props alone left the camera stuck at its constructed default (a ±1 unit
+  // frustum), so it only ever saw a sliver of the nearest surface, filling
+  // the whole canvas with flat grass green. Setting the properties and
+  // updating the matrix explicitly, every frame, fixes it for certain.
+  useFrame(() => {
+    if (!camRef.current) return;
+    const cam = camRef.current;
+    cam.position.set(camX, camY, camZ);
+    cam.lookAt(0, fieldDiag * 0.08, 0);
+    cam.left = -halfWidth;
+    cam.right = halfWidth;
+    cam.top = halfHeight;
+    cam.bottom = -halfHeight;
+    cam.near = 0.1;
+    cam.far = distance * 3;
+    cam.zoom = zoom;
+    cam.updateProjectionMatrix();
+  });
+
+  return <orthographicCamera ref={camRef} />;
+}
+
+function groundTexture(color: string, width: number, depth: number): THREE.Texture | null {
+  const base = getPartTexture(color);
+  if (!base) return null;
+  const tex = base.clone();
+  tex.repeat.set(Math.max(1, Math.round(width)), Math.max(1, Math.round(depth)));
+  tex.needsUpdate = true;
+  return tex;
+}
+
+const TERRAIN_SEGMENTS = 28;
+
+/** A displaced heightfield grid: flat inside the tile footprint (matches
+ * `terrainHeightAt`'s own definition exactly, so the play surface — tile
+ * math, occlusion, `ContactShadows`, grass — stays untouched), rolling hills
+ * in the decorative apron beyond it, out to `TERRAIN_MARGIN`. Built directly
+ * with `three` primitives in the component (same custom-vertex-geometry
+ * pattern `SkyDome` already uses for its own gradient sphere), not a
+ * `planeGeometry` + rotation — X/Z map straight onto the grid so the height
+ * math needs no coordinate-frame juggling. */
+function buildTerrainGeometry(landW: number, landD: number): THREE.BufferGeometry {
+  const outerW = landW + TERRAIN_MARGIN * 2;
+  const outerD = landD + TERRAIN_MARGIN * 2;
+  const segs = TERRAIN_SEGMENTS;
+  const vertsPerRow = segs + 1;
+  const positions = new Float32Array(vertsPerRow * vertsPerRow * 3);
+  const uvs = new Float32Array(vertsPerRow * vertsPerRow * 2);
+
+  let p = 0;
+  let u = 0;
+  for (let j = 0; j <= segs; j++) {
+    const z = (j / segs - 0.5) * outerD;
+    for (let i = 0; i <= segs; i++) {
+      const x = (i / segs - 0.5) * outerW;
+      positions[p++] = x;
+      positions[p++] = terrainHeightAt(x, z, landW / 2, landD / 2);
+      positions[p++] = z;
+      uvs[u++] = i / segs;
+      uvs[u++] = j / segs;
+    }
+  }
+
+  const indices: number[] = [];
+  for (let j = 0; j < segs; j++) {
+    for (let i = 0; i < segs; i++) {
+      const a = j * vertsPerRow + i;
+      const b = a + 1;
+      const c = a + vertsPerRow;
+      const d = c + 1;
+      indices.push(a, c, b, b, c, d);
+    }
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geo.setAttribute("uv", new THREE.BufferAttribute(uvs, 2));
+  geo.setIndex(indices);
+  geo.computeVertexNormals();
+  return geo;
+}
+
+function Ground({ landW, landD }: { landW: number; landD: number }) {
+  // Same grain texture and toon shading the plants use — a flat-colored,
+  // standard-shaded ground next to textured/toon plants read as unfinished.
+  // The field's tile lines don't need a literal `gridHelper` (a default
+  // three.js debug primitive) to be legible; the hover highlight already
+  // marks the active tile.
+  const outerW = landW + TERRAIN_MARGIN * 2;
+  const outerD = landD + TERRAIN_MARGIN * 2;
+  const soilTexture = useMemo(() => groundTexture("#6b4a34", outerW, outerD), [outerW, outerD]);
+  const grassTexture = useMemo(() => groundTexture("#5f8a3f", outerW, outerD), [outerW, outerD]);
+  const gradientMap = useMemo(() => getToonGradientMap(), []);
+  const terrainGeometry = useMemo(() => buildTerrainGeometry(landW, landD), [landW, landD]);
+
+  return (
+    <group>
+      <mesh position={[0, -0.9, 0]}>
+        <boxGeometry args={[outerW, 1.2, outerD]} />
+        <meshToonMaterial color="#6b4a34" map={soilTexture ?? undefined} gradientMap={gradientMap} />
+      </mesh>
+      {/* The rolling terrain surface itself. No inverted-hull outline here
+          (unlike the plants and the old flat slab this replaces) — a
+          heightfield has no real side faces for that trick to rim, and the
+          mesh's own outer edge now sits well past the fence, out of the
+          frame's usual focus. Known ceiling: the grass surface has no
+          thickness, so at extreme zoom-out you could in principle glimpse
+          the flat soil block's edge behind a hill's silhouette — not worth a
+          fully extruded terrain solid for that edge case. */}
+      <mesh geometry={terrainGeometry} receiveShadow>
+        <meshToonMaterial color="#5f8a3f" map={grassTexture ?? undefined} gradientMap={gradientMap} />
+      </mesh>
+    </group>
+  );
+}
+
+function MemberOnTile({
+  member,
+  worldX,
+  worldZ,
+  isHovered,
+  onHoverChange,
+}: {
+  member: GenmateFieldMember;
+  worldX: number;
+  worldZ: number;
+  isHovered: boolean;
+  onHoverChange: (hovered: boolean) => void;
+}) {
+  const parts = useFarmPlantParts(member.species, member.tier, member.palette, member.active);
+  const height = useFarmPlantHeight(parts);
+  const auraSpec = useMemo(() => auraSpecForTier(member.tier), [member.tier]);
+  const particleDefs = useMemo(() => buildParticleDefs(member.tier), [member.tier]);
+  const tierName = getPlantTierConfig(member.tier).name;
+
+  return (
+    <group position={[worldX, 0, worldZ]}>
+      <group
+        onPointerOver={(e) => {
+          e.stopPropagation();
+          onHoverChange(true);
+        }}
+        onPointerOut={(e) => {
+          e.stopPropagation();
+          onHoverChange(false);
+        }}
+      >
+        <PlantMesh species={member.species} tier={member.tier} palette={member.palette} active={member.active} />
+      </group>
+      {particleDefs.length > 0 && auraSpec && (
+        <Particles defs={particleDefs} anchorHeight={height * 0.7} palette={member.palette} glowColor={auraSpec.color} />
+      )}
+      {isHovered && <TileHighlight />}
+      {/* Keyboard access: a real focusable DOM element per tile, not a canvas-only
+          hit region — ticket 05. Same hover treatment fires on focus. */}
+      <Html position={[0, 0.05, 0]} center distanceFactor={undefined} style={{ pointerEvents: "none" }}>
+        <button
+          type="button"
+          onFocus={() => onHoverChange(true)}
+          onBlur={() => onHoverChange(false)}
+          onMouseEnter={() => onHoverChange(true)}
+          onMouseLeave={() => onHoverChange(false)}
+          className="h-2 w-2 rounded-full border-0 bg-transparent p-0 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          style={{ pointerEvents: "auto" }}
+          aria-label={`${member.name}, ${member.displayStreakDays} day streak, ${tierName}`}
+        />
+      </Html>
+      {isHovered && (
+        <Html position={[0, height + 0.6, 0]} center style={{ pointerEvents: "none" }}>
+          <div className="whitespace-nowrap rounded-lg border border-border bg-popover px-3 py-1.5 text-xs shadow-lg">
+            <div className="font-semibold">{member.name}</div>
+            <div className="text-muted-foreground">
+              {member.displayStreakDays} day{member.displayStreakDays === 1 ? "" : "s"} · {tierName}
+            </div>
+          </div>
+        </Html>
+      )}
+    </group>
+  );
+}
+
+function TileHighlight() {
+  return (
+    <mesh position={[0, 0.03, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+      <ringGeometry args={[1.4, 1.7, 24]} />
+      <meshBasicMaterial color="#ffffff" transparent opacity={0.55} toneMapped={false} />
+    </mesh>
+  );
+}
+
+function Particles({
+  defs,
+  anchorHeight,
+  palette,
+  glowColor,
+}: {
+  defs: ParticleDef[];
+  anchorHeight: number;
+  palette: PlantPalette;
+  glowColor: string;
+}) {
+  const groupRef = useRef<THREE.Group>(null);
+  // Matches the real split: petal uses the learner's flower color, leaf uses
+  // their leaf color, pollen/light use the tier's glow color (tier-driven, not
+  // palette-driven, same as the real AuraGlow).
+  const colorFor = (type: ParticleDef["type"]): string =>
+    type === "petal" ? palette.flower : type === "leaf" ? palette.leaf : glowColor;
+
+  useFrame(({ clock }) => {
+    if (!groupRef.current) return;
+    const t = clock.elapsedTime;
+    groupRef.current.children.forEach((child, i) => {
+      const def = defs[i];
+      if (!def) return;
+      const dur = 2.4 + hash(def.seed) * 1.6;
+      const phase = (t % dur) / dur;
+      const rising = isRisingParticle(def.type);
+      const travel = rising ? 1.6 : 2.0;
+      const y = rising ? -phase * travel : -0.5 + phase * travel;
+      const wobble = Math.sin(phase * Math.PI * 2 + def.seed) * 0.28;
+      child.position.set(wobble, y, 0);
+      const alpha = Math.sin(Math.min(Math.max(phase, 0), 1) * Math.PI);
+      const mat = (child as THREE.Mesh).material as THREE.MeshBasicMaterial;
+      mat.opacity = alpha * 0.85;
+    });
+  });
+
+  return (
+    <group ref={groupRef} position={[0, anchorHeight, 0]}>
+      {defs.map((def, i) => (
+        <mesh key={i}>
+          <sphereGeometry args={[def.type === "petal" ? 0.09 : def.type === "leaf" ? 0.08 : 0.05, 4, 3]} />
+          <meshBasicMaterial
+            color={colorFor(def.type)}
+            transparent
+            opacity={0}
+            toneMapped={false}
+            blending={isRisingParticle(def.type) ? THREE.AdditiveBlending : THREE.NormalBlending}
+            depthWrite={false}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function hash(n: number): number {
+  const x = Math.sin(n) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+const BUTTERFLY_COLORS = ["#ffd166", "#ff8fa3", "#8ecae6", "#c8a2ff", "#b8f2b8"];
+
+/** Purely decorative — a handful of butterflies wandering the field on gentle
+ * looping paths, wings flapping. No interaction, no data dependency; the
+ * "cute and funny" ask, not a design decision recorded on any ticket. */
+function Butterflies({ count, spread }: { count: number; spread: number }) {
+  const flies = useMemo(
+    () =>
+      Array.from({ length: count }, (_, i) => ({
+        id: i,
+        color: BUTTERFLY_COLORS[i % BUTTERFLY_COLORS.length],
+        radiusX: spread * (0.4 + hash(i * 3.1) * 0.5),
+        radiusZ: spread * (0.4 + hash(i * 7.7) * 0.5),
+        speed: 0.25 + hash(i * 5.3) * 0.2,
+        phase: hash(i * 9.1) * Math.PI * 2,
+        baseHeight: 1.5 + hash(i * 4.4) * 2,
+        bob: 0.3 + hash(i * 6.6) * 0.3,
+        flapSeed: i * 11.1,
+      })),
+    [count, spread]
+  );
+  return (
+    <>
+      {flies.map((fly) => (
+        <Butterfly key={fly.id} {...fly} />
+      ))}
+    </>
+  );
+}
+
+function Butterfly({
+  color,
+  radiusX,
+  radiusZ,
+  speed,
+  phase,
+  baseHeight,
+  bob,
+  flapSeed,
+}: {
+  color: string;
+  radiusX: number;
+  radiusZ: number;
+  speed: number;
+  phase: number;
+  baseHeight: number;
+  bob: number;
+  flapSeed: number;
+}) {
+  const groupRef = useRef<THREE.Group>(null);
+  const leftWingRef = useRef<THREE.Group>(null);
+  const rightWingRef = useRef<THREE.Group>(null);
+
+  useFrame(({ clock }) => {
+    const t = clock.elapsedTime * speed + phase;
+    if (groupRef.current) {
+      const x = Math.cos(t) * radiusX;
+      const z = Math.sin(t * 1.3) * radiusZ; // figure-8-ish wander, not a plain circle
+      const y = baseHeight + Math.sin(t * 2 + flapSeed) * bob;
+      groupRef.current.position.set(x, y, z);
+      groupRef.current.rotation.y = -t;
+    }
+    const flap = Math.sin(clock.elapsedTime * 14 + flapSeed) * 0.7 + 0.75;
+    if (leftWingRef.current) leftWingRef.current.rotation.y = flap;
+    if (rightWingRef.current) rightWingRef.current.rotation.y = -flap;
+  });
+
+  return (
+    <group ref={groupRef}>
+      <mesh>
+        <sphereGeometry args={[0.045, 4, 3]} />
+        <meshStandardMaterial color="#3d3d3d" />
+      </mesh>
+      <group ref={leftWingRef} position={[0.03, 0, 0]}>
+        <mesh position={[0.09, 0, 0]}>
+          <boxGeometry args={[0.16, 0.02, 0.13]} />
+          <meshBasicMaterial color={color} toneMapped={false} />
+        </mesh>
+      </group>
+      <group ref={rightWingRef} position={[-0.03, 0, 0]}>
+        <mesh position={[-0.09, 0, 0]}>
+          <boxGeometry args={[0.16, 0.02, 0.13]} />
+          <meshBasicMaterial color={color} toneMapped={false} />
+        </mesh>
+      </group>
+    </group>
+  );
+}

--- a/src/components/farm/GrassField.tsx
+++ b/src/components/farm/GrassField.tsx
@@ -1,0 +1,54 @@
+import { useLayoutEffect, useMemo, useRef } from "react";
+import { Color, InstancedMesh, Object3D } from "three";
+import { getToonGradientMap } from "@/lib/farm-textures";
+
+const BLADE_COLORS = ["#5f8a3f", "#6f9c4a", "#547a35"];
+const BLADE_COUNT = 700;
+const BLADE_HEIGHT = 0.32;
+
+function hash(n: number): number {
+  const x = Math.sin(n) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+interface GrassFieldProps {
+  landW: number;
+  landD: number;
+}
+
+/** Real grass blades instead of a flat green box — one instanced draw call
+ * scattered across the field, not outlined individually (an inverted-hull
+ * copy per blade would double the instance count and read as noise at this
+ * scale rather than the clean toylike rim that works for larger shapes). */
+export function GrassField({ landW, landD }: GrassFieldProps) {
+  const meshRef = useRef<InstancedMesh>(null);
+  const gradientMap = useMemo(() => getToonGradientMap(), []);
+
+  useLayoutEffect(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+    const dummy = new Object3D();
+    const color = new Color();
+    for (let i = 0; i < BLADE_COUNT; i++) {
+      const x = (hash(i * 12.9898) - 0.5) * landW * 0.94;
+      const z = (hash(i * 78.233) - 0.5) * landD * 0.94;
+      const scale = 0.6 + hash(i * 3.71) * 0.8;
+      dummy.position.set(x, (BLADE_HEIGHT / 2) * scale, z);
+      dummy.rotation.y = hash(i * 5.31) * Math.PI * 2;
+      dummy.scale.setScalar(scale);
+      dummy.updateMatrix();
+      mesh.setMatrixAt(i, dummy.matrix);
+      color.set(BLADE_COLORS[i % BLADE_COLORS.length]);
+      mesh.setColorAt(i, color);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [landW, landD]);
+
+  return (
+    <instancedMesh ref={meshRef} args={[undefined, undefined, BLADE_COUNT]} position={[0, 0.02, 0]}>
+      <boxGeometry args={[0.05, BLADE_HEIGHT, 0.02]} />
+      <meshToonMaterial gradientMap={gradientMap} vertexColors />
+    </instancedMesh>
+  );
+}

--- a/src/components/farm/PlantMesh.tsx
+++ b/src/components/farm/PlantMesh.tsx
@@ -1,0 +1,109 @@
+import { useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { BackSide, type Group } from "three";
+import type { PlantPalette, PlantSpecies } from "@/lib/plant-variants";
+import type { PlantTier } from "@/lib/streak-milestones";
+import type { FarmPart } from "@/lib/farm-geometry";
+import { useFarmPlantParts } from "@/hooks/use-farm-plant";
+import { getPartTexture, getToonGradientMap, repeatForPart } from "@/lib/farm-textures";
+
+export const OUTLINE_SCALE = 1.06;
+export const OUTLINE_COLOR = "#1a1410";
+
+interface PlantMeshProps {
+  species: PlantSpecies;
+  tier: PlantTier;
+  palette: PlantPalette;
+  /** Matches SeedlingPlant's `active` — false (streak lapsed) renders grey, same shape. */
+  active: boolean;
+}
+
+const GROW_DURATION_S = 1.2;
+
+/**
+ * When (species/archetype, tier, palette, active) changes — a genmate's plant
+ * leveling up while you're looking at the field, since fertilize/rescue
+ * already invalidate and refetch — the new shape grows into place instead of
+ * swapping instantly. Ticket 04's decision, chosen for consistency with the
+ * brand's celebratory tone and the existing milestone-toast precedent.
+ *
+ * This is a whole-plant scale grow, not a true per-part morph between the old
+ * and new geometry: the two states can have entirely different part counts
+ * (a 3-segment stem becoming a 4-segment one), so there's no natural 1:1
+ * mapping to interpolate between. A uniform ease-out scale from a genmate
+ * seeing it at rest to full size reads as "growing" without needing to solve
+ * that harder problem.
+ */
+export function PlantMesh({ species, tier, palette, active }: PlantMeshProps) {
+  const parts = useFarmPlantParts(species, tier, palette, active);
+  const groupRef = useRef<Group>(null);
+  const growElapsed = useRef(GROW_DURATION_S); // starts fully grown; only animates on a later change
+  const prevPartsRef = useRef(parts);
+
+  if (prevPartsRef.current !== parts) {
+    growElapsed.current = 0;
+    prevPartsRef.current = parts;
+  }
+
+  useFrame((_, delta) => {
+    if (growElapsed.current >= GROW_DURATION_S || !groupRef.current) return;
+    growElapsed.current = Math.min(GROW_DURATION_S, growElapsed.current + delta);
+    const t = growElapsed.current / GROW_DURATION_S;
+    const eased = 1 - (1 - t) ** 3;
+    const scale = 0.75 + 0.25 * eased;
+    groupRef.current.scale.setScalar(scale);
+  });
+
+  return (
+    <group ref={groupRef}>
+      {parts.map((part, i) => (
+        <PartMesh key={i} part={part} />
+      ))}
+    </group>
+  );
+}
+
+function PartGeometry({ part }: { part: FarmPart }) {
+  if (part.kind === "cylinder") return <cylinderGeometry args={part.args as [number, number, number, number]} />;
+  if (part.kind === "sphere") return <sphereGeometry args={part.args as [number, number, number]} />;
+  if (part.kind === "box") return <boxGeometry args={part.args as [number, number, number]} />;
+  return <torusGeometry args={part.args as [number, number, number, number, number]} />;
+}
+
+export function PartMesh({ part }: { part: FarmPart }) {
+  const texture = useMemo(() => {
+    const base = getPartTexture(part.color);
+    if (!base) return null;
+    const tex = base.clone();
+    const [repeatX, repeatY] = repeatForPart(part);
+    tex.repeat.set(repeatX, repeatY);
+    tex.needsUpdate = true;
+    return tex;
+  }, [part]);
+  const gradientMap = useMemo(() => getToonGradientMap(), []);
+  const scale = part.scale ?? [1, 1, 1];
+  const outlineScale: [number, number, number] = [scale[0] * OUTLINE_SCALE, scale[1] * OUTLINE_SCALE, scale[2] * OUTLINE_SCALE];
+
+  const mesh = (
+    <group position={part.position} rotation={part.rotation ?? [0, 0, 0]}>
+      {/* Inverted-hull outline: a slightly larger, backface-only black copy
+          rendered behind the real mesh — the "toylike" cel-shaded rim, cheaper
+          and more reliable here than an edge-detection post-process since it
+          needs no per-mesh selection wiring. */}
+      <mesh scale={outlineScale}>
+        <PartGeometry part={part} />
+        <meshBasicMaterial color={OUTLINE_COLOR} side={BackSide} />
+      </mesh>
+      <mesh castShadow scale={scale}>
+        <PartGeometry part={part} />
+        <meshToonMaterial color={part.color} map={texture ?? undefined} gradientMap={gradientMap} />
+      </mesh>
+    </group>
+  );
+  if (!part.pivot) return mesh;
+  return (
+    <group position={part.pivot.position} rotation={part.pivot.rotation}>
+      {mesh}
+    </group>
+  );
+}

--- a/src/components/farm/SkyDome.tsx
+++ b/src/components/farm/SkyDome.tsx
@@ -1,0 +1,156 @@
+import { useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import { AdditiveBlending, BackSide, BufferAttribute, Color, Group, SphereGeometry, Vector3 } from "three";
+
+const TOP_COLOR = "#7ab8dd";
+const HORIZON_COLOR = "#e8d9ae";
+const SUN_COLOR = "#ffe9a3";
+const CLOUD_COLOR = "#fdfaf3";
+const CLOUD_COUNT = 6;
+
+function hash(n: number): number {
+  const x = Math.sin(n) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+interface SkyDomeProps {
+  radius: number;
+  /** Same direction the scene's key light shines from, so the visible sun
+   * sits where the light actually comes from instead of floating decoratively
+   * in an unrelated part of the sky. */
+  sunDirection: [number, number, number];
+}
+
+/**
+ * A vertex-colored gradient sky dome, a sun anchored to the actual key
+ * light's direction, and a handful of slowly drifting clouds — replacing the
+ * flat CSS gradient that used to sit as page chrome behind the canvas. Being
+ * part of the actual scene means it's lit consistently with everything else
+ * instead of a static backdrop that doesn't react to anything.
+ *
+ * Plain vertex colors on a sphere rather than a custom shader — no GLSL
+ * needed for a two-stop gradient, and it composes with the existing
+ * toon/outline pipeline without a new material type to reason about. Clouds
+ * stay a plain unlit color (no toon/outline treatment) — this far from the
+ * subject and this small on screen, the outline pass would read as noise
+ * rather than the clean rim that works for the plants and ground.
+ */
+export function SkyDome({ radius, sunDirection }: SkyDomeProps) {
+  const geometry = useMemo(() => {
+    const geo = new SphereGeometry(radius, 24, 16);
+    const pos = geo.attributes.position;
+    const colors = new Float32Array(pos.count * 3);
+    const top = new Color(TOP_COLOR);
+    const horizon = new Color(HORIZON_COLOR);
+    const tmp = new Color();
+    for (let i = 0; i < pos.count; i++) {
+      const t = Math.max(0, Math.min(1, pos.getY(i) / radius + 0.15));
+      tmp.copy(horizon).lerp(top, t);
+      colors[i * 3] = tmp.r;
+      colors[i * 3 + 1] = tmp.g;
+      colors[i * 3 + 2] = tmp.b;
+    }
+    geo.setAttribute("color", new BufferAttribute(colors, 3));
+    return geo;
+  }, [radius]);
+
+  const sunPosition = useMemo(() => {
+    const dir = new Vector3(...sunDirection).normalize().multiplyScalar(radius * 0.9);
+    return [dir.x, dir.y, dir.z] as [number, number, number];
+  }, [radius, sunDirection]);
+
+  return (
+    <group>
+      {/* Tone-mapped like everything else in the scene — a background this
+          large left non-tone-mapped registered as bright enough to trip
+          Bloom's luminance threshold across the whole frame, reading as a
+          hazy/blurred backdrop instead of a plain sky. */}
+      <mesh geometry={geometry} renderOrder={-1}>
+        <meshBasicMaterial vertexColors side={BackSide} depthWrite={false} />
+      </mesh>
+      <mesh position={sunPosition}>
+        <sphereGeometry args={[radius * 0.05, 10, 8]} />
+        <meshBasicMaterial color={SUN_COLOR} toneMapped={false} depthWrite={false} />
+      </mesh>
+      <mesh position={sunPosition} scale={1.6}>
+        <sphereGeometry args={[radius * 0.05, 10, 8]} />
+        <meshBasicMaterial
+          color={SUN_COLOR}
+          transparent
+          opacity={0.2}
+          toneMapped={false}
+          depthWrite={false}
+          blending={AdditiveBlending}
+        />
+      </mesh>
+      <Clouds radius={radius} />
+    </group>
+  );
+}
+
+interface CloudPuff {
+  x: number;
+  y: number;
+  z: number;
+  r: number;
+}
+interface CloudDef {
+  angle0: number;
+  height: number;
+  speed: number;
+  orbitRadius: number;
+  puffs: CloudPuff[];
+}
+
+function Clouds({ radius }: { radius: number }) {
+  const groupRefs = useRef<(Group | null)[]>([]);
+
+  const cloudDefs = useMemo<CloudDef[]>(() => {
+    const orbitRadius = radius * 0.85;
+    return Array.from({ length: CLOUD_COUNT }, (_, i) => {
+      const puffCount = 4 + Math.floor(hash(i * 2.2) * 2);
+      const puffs: CloudPuff[] = Array.from({ length: puffCount }, (_, j) => ({
+        x: (hash(i * 11 + j * 3) - 0.5) * radius * 0.06,
+        y: (hash(i * 13 + j * 5) - 0.5) * radius * 0.015,
+        z: (hash(i * 17 + j * 7) - 0.5) * radius * 0.03,
+        r: radius * (0.02 + hash(i * 19 + j * 2) * 0.015),
+      }));
+      return {
+        angle0: (i / CLOUD_COUNT) * Math.PI * 2 + hash(i * 3.3) * 0.6,
+        height: radius * (0.15 + hash(i * 7.1) * 0.2),
+        speed: 0.01 + hash(i * 5.5) * 0.015,
+        orbitRadius,
+        puffs,
+      };
+    });
+  }, [radius]);
+
+  useFrame(({ clock }) => {
+    cloudDefs.forEach((def, i) => {
+      const group = groupRefs.current[i];
+      if (!group) return;
+      const angle = def.angle0 + clock.elapsedTime * def.speed;
+      group.position.set(Math.cos(angle) * def.orbitRadius, def.height, Math.sin(angle) * def.orbitRadius);
+    });
+  });
+
+  return (
+    <>
+      {cloudDefs.map((def, i) => (
+        <group
+          key={i}
+          ref={(el) => {
+            groupRefs.current[i] = el;
+          }}
+        >
+          {def.puffs.map((p, j) => (
+            <mesh key={j} position={[p.x, p.y, p.z]}>
+              <sphereGeometry args={[p.r, 8, 6]} />
+              <meshBasicMaterial color={CLOUD_COLOR} />
+            </mesh>
+          ))}
+        </group>
+      ))}
+    </>
+  );
+}

--- a/src/components/genmate-garden.tsx
+++ b/src/components/genmate-garden.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, type MouseEvent } from "react";
+import React, { Suspense, useMemo, useState, type MouseEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { Sprout } from "lucide-react";
 import { toast } from "sonner";
@@ -17,10 +17,14 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { SkeletonWarm } from "@/components/loading-skeleton";
 import { BoardReactionPicker } from "@/components/board-reaction-picker";
 import { BoardReactionSummary } from "@/components/board-reaction-summary";
 import { api } from "@/lib/api";
+import { toFarmMembers } from "@/lib/genmate-garden";
+import { useWebglSupported } from "@/hooks/use-webgl-support";
 import { getPlantVariant } from "@/lib/plant-variants";
 import {
   getPlantTier,
@@ -85,7 +89,17 @@ interface GenmateGardenProps {
   cohort?: string;
 }
 
+// three.js only loads once an admin flips to Farm — same lazy boundary as
+// the learner-facing garden pages.
+const GenmateField = React.lazy(() =>
+  import("@/components/farm/GenmateField").then((mod) => ({ default: mod.GenmateField }))
+);
+
+type ViewMode = "grid" | "farm";
+
 export function GenmateGarden({ cohort }: GenmateGardenProps) {
+  const [view, setView] = useState<ViewMode>("grid");
+  const webglSupported = useWebglSupported();
   const { data, isLoading, isError, refetch } = useQuery<AdminUsersResponse>(
     ["adminGenmateGarden", cohort],
     () =>
@@ -210,11 +224,39 @@ export function GenmateGarden({ cohort }: GenmateGardenProps) {
     );
   }
 
+  const handleFarmContextLost = () => {
+    setView("grid");
+    toast.error("3D view lost — showing the grid instead");
+  };
+
   return (
     <div className="flex flex-col gap-6">
-      <p className="text-sm text-muted-foreground">
-        {cohort ? `Cohort ${cohort}` : "All cohorts"} · {groupedLearnerCount} learners across {groups.length} genmate group{groups.length === 1 ? "" : "s"}
-      </p>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          {cohort ? `Cohort ${cohort}` : "All cohorts"} · {groupedLearnerCount} learners across {groups.length} genmate group{groups.length === 1 ? "" : "s"}
+        </p>
+        <Tabs value={view} onValueChange={(v) => setView(v as ViewMode)}>
+          <TabsList>
+            <TabsTrigger value="grid">Grid</TabsTrigger>
+            {webglSupported ? (
+              <TabsTrigger value="farm">Farm</TabsTrigger>
+            ) : (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <TabsTrigger value="farm" disabled>
+                        Farm
+                      </TabsTrigger>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>3D view isn't supported on this device</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </TabsList>
+        </Tabs>
+      </div>
 
       {groups.map((group) => (
         <Card key={group.name} className="w-full">
@@ -227,11 +269,20 @@ export function GenmateGarden({ cohort }: GenmateGardenProps) {
             </div>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-              {group.members.map((member) => (
-                <PlantTile key={member.user._id} member={member} />
-              ))}
-            </div>
+            {view === "grid" ? (
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+                {group.members.map((member) => (
+                  <PlantTile key={member.user._id} member={member} />
+                ))}
+              </div>
+            ) : (
+              <Suspense fallback={<SkeletonWarm className="aspect-[4/3] w-full rounded-xl" />}>
+                <GenmateField
+                  members={toFarmMembers(group.members)}
+                  onContextLost={handleFarmContextLost}
+                />
+              </Suspense>
+            )}
           </CardContent>
         </Card>
       ))}

--- a/src/domain/types/user.ts
+++ b/src/domain/types/user.ts
@@ -107,6 +107,19 @@ export interface GenmateGardenResponse {
   };
 }
 
+export interface CohortGardenGroup {
+  group_name: string;
+  members: GenmateGardenMember[];
+}
+
+export interface CohortGardenResponse {
+  status: string;
+  message: string;
+  data: {
+    groups: CohortGardenGroup[];
+  };
+}
+
 export interface JWTPayload {
   user_id: string;
   cohort?: number;

--- a/src/hooks/use-farm-plant.ts
+++ b/src/hooks/use-farm-plant.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import type { PlantPalette, PlantSpecies } from "@/lib/plant-variants";
+import { getPlantTierConfig, type PlantTier } from "@/lib/streak-milestones";
+import { getCachedPlantParts, maxPartHeight, type FarmPart } from "@/lib/farm-geometry";
+
+/**
+ * Pulls from the ticket-04 module-level cache — calling this from both
+ * `PlantMesh` and a parent scene (for aura/hit-box height) is cheap, the
+ * second call is a cache hit, not a rebuild.
+ */
+export function useFarmPlantParts(species: PlantSpecies, tier: PlantTier, palette: PlantPalette, active: boolean): FarmPart[] {
+  return useMemo(
+    () => getCachedPlantParts(species, tier, palette, getPlantTierConfig(tier), active),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [species, tier, palette.name, active]
+  );
+}
+
+export function useFarmPlantHeight(parts: FarmPart[]): number {
+  return useMemo(() => maxPartHeight(parts), [parts]);
+}

--- a/src/hooks/use-webgl-support.ts
+++ b/src/hooks/use-webgl-support.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+/**
+ * No WebGL: the Farm toggle stays visible but disabled, with a tooltip —
+ * ticket 05. Detected once; WebGL support doesn't change mid-session.
+ */
+export function useWebglSupported(): boolean {
+  const [supported] = useState(() => {
+    try {
+      const canvas = document.createElement("canvas");
+      return !!(canvas.getContext("webgl2") || canvas.getContext("webgl"));
+    } catch {
+      return false;
+    }
+  });
+  return supported;
+}
+
+/**
+ * Context lost mid-session (driver crash, tab backgrounded, GPU pressure):
+ * auto-fall back to the grid with a toast, no dead canvas — ticket 05.
+ */
+export function useFarmContextLost(onLost: () => void): { lost: boolean; handleContextLost: () => void } {
+  const [lost, setLost] = useState(false);
+
+  useEffect(() => {
+    if (!lost) return;
+    onLost();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lost]);
+
+  return { lost, handleContextLost: () => setLost(true) };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -27,7 +27,7 @@ export {
   deletePost,
   deleteComment,
 } from "../application/services/boardService";
-export { getAllUsers, getCohort, deleteUserById, getMyGenmateGarden } from "../application/services/userService";
+export { getAllUsers, getCohort, deleteUserById, getMyGenmateGarden, getCohortGarden } from "../application/services/userService";
 export { getWeeklyReflections, createReflection, getBarometerData } from "../application/services/reflectionService";
 export {
   listCohorts,

--- a/src/lib/farm-decorations.test.ts
+++ b/src/lib/farm-decorations.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { buildFenceParts, buildGroundProps, buildBackgroundTrees } from "@/lib/farm-decorations";
+
+function expectFinite(parts: ReturnType<typeof buildFenceParts>) {
+  for (const part of parts) {
+    for (const n of [...part.position, ...(part.args as number[]), ...(part.rotation ?? []), ...(part.scale ?? [])]) {
+      expect(Number.isFinite(n)).toBe(true);
+    }
+  }
+}
+
+describe("buildFenceParts", () => {
+  it("produces only finite geometry for a range of field sizes", () => {
+    for (const [w, d] of [[10, 10], [25.8, 25.8], [40, 60]]) {
+      expectFinite(buildFenceParts(w, d));
+    }
+  });
+
+  it("scales up (more posts) for a larger field", () => {
+    expect(buildFenceParts(60, 60).length).toBeGreaterThan(buildFenceParts(10, 10).length);
+  });
+});
+
+describe("buildGroundProps", () => {
+  it("returns nothing for an empty tile list", () => {
+    expect(buildGroundProps([])).toEqual([]);
+  });
+
+  it("produces only finite geometry, deterministically (same input → same output)", () => {
+    const tiles = [{ x: 5, z: -5 }, { x: -5, z: 5 }, { x: 0, z: 0 }];
+    const a = buildGroundProps(tiles);
+    const b = buildGroundProps(tiles);
+    expectFinite(a);
+    expect(a).toEqual(b);
+  });
+
+  it("produces at least one part per empty tile", () => {
+    const tiles = [{ x: 1, z: 1 }, { x: 2, z: 2 }, { x: 3, z: 3 }, { x: 4, z: 4 }];
+    const parts = buildGroundProps(tiles);
+    expect(parts.length).toBeGreaterThanOrEqual(tiles.length);
+  });
+});
+
+describe("buildBackgroundTrees", () => {
+  it("produces only finite geometry for a range of field sizes", () => {
+    for (const [w, d] of [[10, 10], [25.8, 25.8], [40, 60]]) {
+      expectFinite(buildBackgroundTrees(w, d));
+    }
+  });
+
+  it("is deterministic — same input produces the same output", () => {
+    expect(buildBackgroundTrees(20, 20)).toEqual(buildBackgroundTrees(20, 20));
+  });
+
+  it("places every tree outside the field's own footprint", () => {
+    const landW = 20;
+    const landD = 20;
+    const parts = buildBackgroundTrees(landW, landD);
+    for (const part of parts) {
+      const [x, , z] = part.position;
+      const outsideX = Math.abs(x) > landW / 2;
+      const outsideZ = Math.abs(z) > landD / 2;
+      expect(outsideX || outsideZ).toBe(true);
+    }
+  });
+
+  it("sits trees on the terrain's rolling apron, not a fixed Y", () => {
+    const landW = 20;
+    const landD = 20;
+    const parts = buildBackgroundTrees(landW, landD);
+    const trunkYs = parts.filter((p) => p.kind === "cylinder").map((p) => p.position[1]);
+    const distinctYs = new Set(trunkYs.map((y) => Math.round(y * 1000)));
+    expect(distinctYs.size).toBeGreaterThan(1);
+  });
+});

--- a/src/lib/farm-decorations.ts
+++ b/src/lib/farm-decorations.ts
@@ -1,0 +1,162 @@
+import type { FarmPart } from "@/lib/farm-geometry";
+import { terrainHeightAt } from "@/lib/farm-terrain";
+
+function offsetPartsY(parts: FarmPart[], dy: number): FarmPart[] {
+  if (dy === 0) return parts;
+  return parts.map((p) => ({ ...p, position: [p.position[0], p.position[1] + dy, p.position[2]] }));
+}
+
+function hash(n: number): number {
+  const x = Math.sin(n) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+/**
+ * A light picket fence around the field perimeter — reinforces "farm" and
+ * gives the land a finished edge. Purely decorative, no interaction.
+ */
+export function buildFenceParts(landW: number, landD: number): FarmPart[] {
+  const parts: FarmPart[] = [];
+  const postH = 0.9, postSpacing = 1.6, railY = 0.45;
+  const postColor = "#f3ead9", railColor = "#e8dcc4";
+
+  function edge(length: number, along: "x" | "z", fixedOther: number) {
+    const count = Math.max(2, Math.round(length / postSpacing));
+    for (let i = 0; i <= count; i++) {
+      const t = (i / count - 0.5) * length;
+      const x = along === "x" ? t : fixedOther;
+      const z = along === "x" ? fixedOther : t;
+      parts.push({ kind: "cylinder", args: [0.06, 0.06, postH, 5], position: [x, postH / 2, z], color: postColor });
+    }
+    const railArgs: [number, number, number] = along === "x" ? [length, 0.08, 0.05] : [0.05, 0.08, length];
+    parts.push({
+      kind: "box",
+      args: railArgs,
+      position: along === "x" ? [0, railY, fixedOther] : [fixedOther, railY, 0],
+      color: railColor,
+    });
+  }
+
+  const half = 0.02; // sit just outside the grass edge, avoiding z-fighting
+  edge(landW, "x", -landD / 2 - half);
+  edge(landW, "x", landD / 2 + half);
+  edge(landD, "z", -landW / 2 - half);
+  edge(landD, "z", landW / 2 + half);
+  return parts;
+}
+
+/** A tiny toadstool prop — decorative only, unrelated to the Mushroom archetype. */
+function toadstoolProp(x: number, z: number, seed: number): FarmPart[] {
+  const scale = 0.55 + hash(seed) * 0.2;
+  const stalkH = 0.5 * scale;
+  return [
+    { kind: "cylinder", args: [0.09 * scale, 0.12 * scale, stalkH, 6], position: [x, stalkH / 2, z], color: "#f3ead9" },
+    { kind: "sphere", args: [0.32 * scale, 8, 5], position: [x, stalkH, z], color: "#d6432f", scale: [1, 0.6, 1] },
+    { kind: "sphere", args: [0.05 * scale, 4, 3], position: [x - 0.14 * scale, stalkH + 0.06 * scale, z], color: "#fff6e8" },
+    { kind: "sphere", args: [0.05 * scale, 4, 3], position: [x + 0.15 * scale, stalkH + 0.03 * scale, z + 0.05 * scale], color: "#fff6e8" },
+  ];
+}
+
+/** A little cluster of round pebbles. */
+function pebbleProp(x: number, z: number, seed: number): FarmPart[] {
+  const parts: FarmPart[] = [];
+  const count = 3 + Math.floor(hash(seed) * 2);
+  for (let i = 0; i < count; i++) {
+    const a = hash(seed + i * 3.1) * Math.PI * 2;
+    const d = hash(seed + i * 5.7) * 0.25;
+    const r = 0.08 + hash(seed + i * 2.3) * 0.07;
+    parts.push({
+      kind: "sphere",
+      args: [r, 5, 4],
+      position: [x + d * Math.cos(a), r * 0.7, z + d * Math.sin(a)],
+      color: i % 2 === 0 ? "#9a998f" : "#b6b4a6",
+      scale: [1, 0.7, 1],
+    });
+  }
+  return parts;
+}
+
+/** A small tuft of flowers, cheaper and simpler than a full archetype. */
+function flowerTuftProp(x: number, z: number, seed: number): FarmPart[] {
+  const colors = ["#ff8fa3", "#ffd166", "#c8a2ff"];
+  const parts: FarmPart[] = [];
+  const count = 3;
+  for (let i = 0; i < count; i++) {
+    const a = (i / count) * Math.PI * 2 + hash(seed + i) * 1.5;
+    const d = 0.1 + hash(seed + i * 4.2) * 0.12;
+    parts.push({ kind: "cylinder", args: [0.02, 0.03, 0.25, 4], position: [x + d * Math.cos(a), 0.125, z + d * Math.sin(a)], color: "#5f8a3f" });
+    parts.push({ kind: "sphere", args: [0.08, 5, 4], position: [x + d * Math.cos(a), 0.28, z + d * Math.sin(a)], color: colors[i % colors.length] });
+  }
+  return parts;
+}
+
+/**
+ * Scatters a small decorative prop on each unoccupied tile so empty grass
+ * doesn't just look bare — cycles through three prop types for variety,
+ * chosen deterministically by tile index so it doesn't reshuffle on redraw.
+ */
+export function buildGroundProps(emptyTiles: Array<{ x: number; z: number }>): FarmPart[] {
+  const builders = [toadstoolProp, pebbleProp, flowerTuftProp];
+  return emptyTiles.flatMap((tile, i) => builders[i % builders.length](tile.x, tile.z, i * 13.7 + 4.1));
+}
+
+/** A simple stylized tree — pure atmosphere, not tied to any learner's
+ * plant, distinct from the Canopy archetype's genmate trees. */
+function backgroundTreeProp(x: number, z: number, seed: number): FarmPart[] {
+  const scale = 0.8 + hash(seed) * 0.6;
+  const trunkH = 1.1 * scale;
+  const leafColors = ["#4d7c3f", "#5f8a3f", "#3f6b32"];
+  const parts: FarmPart[] = [
+    { kind: "cylinder", args: [0.12 * scale, 0.18 * scale, trunkH, 6], position: [x, trunkH / 2, z], color: "#7a5a3a" },
+  ];
+  const canopyY = trunkH + 0.35 * scale;
+  const blobs = 4;
+  for (let i = 0; i < blobs; i++) {
+    const a = (i / blobs) * Math.PI * 2 + hash(seed + i * 2.2) * 1.2;
+    const d = (0.12 + hash(seed + i * 4.4) * 0.1) * scale;
+    const r = (0.35 + hash(seed + i * 6.6) * 0.15) * scale;
+    parts.push({
+      kind: "sphere",
+      args: [r, 7, 5],
+      position: [x + d * Math.cos(a), canopyY + hash(seed + i * 8.8) * 0.3 * scale, z + d * Math.sin(a)],
+      color: leafColors[i % leafColors.length],
+      scale: [1, 0.85, 1],
+    });
+  }
+  return parts;
+}
+
+/**
+ * A handful of decorative trees scattered just outside the fence line —
+ * fills out the "empty field" feeling without touching tile layout or being
+ * tied to any genmate's own plant. Sits on the terrain's rolling apron
+ * (`terrainHeightAt`) rather than a fixed Y=0, since this zone is exactly
+ * where the ground now has real height variation.
+ */
+export function buildBackgroundTrees(landW: number, landD: number): FarmPart[] {
+  const count = 6;
+  const parts: FarmPart[] = [];
+  for (let i = 0; i < count; i++) {
+    const side = i % 4;
+    const along = hash(i * 17.3 + 2) - 0.5;
+    const margin = 1.4 + hash(i * 9.1) * 1.2;
+    let x = 0;
+    let z = 0;
+    if (side === 0) {
+      x = along * landW;
+      z = -landD / 2 - margin;
+    } else if (side === 1) {
+      x = along * landW;
+      z = landD / 2 + margin;
+    } else if (side === 2) {
+      x = -landW / 2 - margin;
+      z = along * landD;
+    } else {
+      x = landW / 2 + margin;
+      z = along * landD;
+    }
+    const groundY = terrainHeightAt(x, z, landW / 2, landD / 2);
+    parts.push(...offsetPartsY(backgroundTreeProp(x, z, i * 23.7 + 6.1), groundY));
+  }
+  return parts;
+}

--- a/src/lib/farm-geometry.test.ts
+++ b/src/lib/farm-geometry.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import { getAllPalettes } from "@/lib/plant-variants";
+import { getPlantTierConfig, type PlantTier } from "@/lib/streak-milestones";
+import {
+  archetypeForSpecies,
+  buildArchetypeParts,
+  buildPlantParts,
+  getCachedPlantParts,
+  maxPartHeight,
+  maxHorizontalExtent,
+  FARM_ARCHETYPE_ORDER,
+} from "@/lib/farm-geometry";
+
+const ALL_SPECIES = [
+  "flower", "cactus", "succulent", "tree", "fern", "vine", "bamboo", "palm",
+  "mushroom", "pine", "clover", "orchid", "coral", "grass", "lotus", "bonsai", "flytrap",
+  "sunflower", "topiary", "strawberry", "tulip", "pumpkin-vine",
+] as const;
+
+const TIERS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] as const satisfies readonly PlantTier[];
+
+describe("archetypeForSpecies", () => {
+  it("maps every one of the 22 real species to one of the 8 archetypes — ticket 09", () => {
+    for (const species of ALL_SPECIES) {
+      expect(FARM_ARCHETYPE_ORDER).toContain(archetypeForSpecies(species));
+    }
+  });
+});
+
+describe("buildArchetypeParts", () => {
+  const palettes = getAllPalettes();
+
+  it("produces only finite coordinates across every archetype × tier × palette", () => {
+    for (const archetype of FARM_ARCHETYPE_ORDER) {
+      for (const tier of TIERS) {
+        const tierConfig = getPlantTierConfig(tier);
+        for (const palette of palettes) {
+          const parts = buildArchetypeParts(archetype, tier, palette, tierConfig);
+          expect(parts.length).toBeGreaterThan(0);
+          for (const part of parts) {
+            for (const n of [...part.position, ...(part.args as number[])]) {
+              expect(Number.isFinite(n)).toBe(true);
+            }
+            if (part.pivot) {
+              for (const n of [...part.pivot.position, ...part.pivot.rotation]) {
+                expect(Number.isFinite(n)).toBe(true);
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  it("is a pure function — same inputs produce structurally identical output", () => {
+    const tierConfig = getPlantTierConfig(7);
+    const a = buildArchetypeParts("bloom", 7, palettes[0], tierConfig);
+    const b = buildArchetypeParts("bloom", 7, palettes[0], tierConfig);
+    expect(a).toEqual(b);
+  });
+
+  it("renders visibly larger geometry at higher tiers — the actual growth", () => {
+    const forest = palettes.find((p) => p.name === "Forest")!;
+    for (const archetype of FARM_ARCHETYPE_ORDER) {
+      const short = maxPartHeight(buildArchetypeParts(archetype, 1, forest, getPlantTierConfig(1)));
+      const tall = maxPartHeight(buildArchetypeParts(archetype, 9, forest, getPlantTierConfig(9)));
+      expect(tall).toBeGreaterThan(short);
+    }
+  });
+});
+
+describe("active vs. inactive (streak-lapsed) coloring — matches SeedlingPlant's grey fallback", () => {
+  it("uses grey, not the palette color, when active is false", () => {
+    const forest = getAllPalettes().find((p) => p.name === "Forest")!;
+    const tierConfig = getPlantTierConfig(7);
+    const active = buildArchetypeParts("bloom", 7, forest, tierConfig, true);
+    const inactive = buildArchetypeParts("bloom", 7, forest, tierConfig, false);
+    const activeColors = new Set(active.map((p) => p.color));
+    const inactiveColors = new Set(inactive.map((p) => p.color));
+    expect(activeColors.has(forest.stem)).toBe(true);
+    expect(inactiveColors.has(forest.stem)).toBe(false);
+    expect(inactiveColors.has("#a1a1aa")).toBe(true); // real SeedlingPlant grey stem fallback
+  });
+
+  it("does not change the plant's own height — only color, plus the active-only face", () => {
+    const forest = getAllPalettes().find((p) => p.name === "Forest")!;
+    const tierConfig = getPlantTierConfig(7);
+    const active = buildArchetypeParts("bloom", 7, forest, tierConfig, true);
+    const inactive = buildArchetypeParts("bloom", 7, forest, tierConfig, false);
+    expect(maxPartHeight(active)).toBeCloseTo(maxPartHeight(inactive), 10);
+    // Active gets the 5-part cute pot face (2 eyes, a smile, 2 blush cheeks) —
+    // matches the real 2D SeedlingPlant, which only draws the face when active.
+    expect(active.length).toBe(inactive.length + 5);
+  });
+});
+
+describe("potFaceParts — the cute face, ported from the real 2D pot", () => {
+  it("only appears when active, matching SeedlingPlant's exact gating", () => {
+    const forest = getAllPalettes().find((p) => p.name === "Forest")!;
+    const tierConfig = getPlantTierConfig(5);
+    for (const archetype of FARM_ARCHETYPE_ORDER) {
+      const active = buildArchetypeParts(archetype, 5, forest, tierConfig, true);
+      const inactive = buildArchetypeParts(archetype, 5, forest, tierConfig, false);
+      expect(active.length - inactive.length).toBe(5);
+    }
+  });
+
+  it("produces only finite geometry, including the new torus smile", () => {
+    const forest = getAllPalettes().find((p) => p.name === "Forest")!;
+    const parts = buildArchetypeParts("bloom", 5, forest, getPlantTierConfig(5), true);
+    const torusParts = parts.filter((p) => p.kind === "torus");
+    expect(torusParts.length).toBe(1);
+    for (const part of torusParts) {
+      for (const n of [...part.position, ...part.rotation!, ...(part.args as number[])]) {
+        expect(Number.isFinite(n)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("getCachedPlantParts — ticket 04's cache", () => {
+  it("returns the same array reference for the same (archetype, tier, palette)", () => {
+    const forest = getAllPalettes().find((p) => p.name === "Forest")!;
+    const tierConfig = getPlantTierConfig(6);
+    const a = getCachedPlantParts("flower", 6, forest, tierConfig);
+    const b = getCachedPlantParts("flower", 6, forest, tierConfig);
+    expect(a).toBe(b);
+  });
+
+  it("shares one cache entry across two species mapping to the same archetype", () => {
+    // "flower" and "tulip" both resolve to Bloom — deliberately not part of the
+    // cache key, since they'd produce identical geometry.
+    const forest = getAllPalettes().find((p) => p.name === "Forest")!;
+    const tierConfig = getPlantTierConfig(6);
+    const flower = getCachedPlantParts("flower", 6, forest, tierConfig);
+    const tulip = getCachedPlantParts("tulip", 6, forest, tierConfig);
+    expect(flower).toBe(tulip);
+  });
+
+  it("keys active vs. inactive separately, so grey never leaks into the active cache slot", () => {
+    const forest = getAllPalettes().find((p) => p.name === "Forest")!;
+    const tierConfig = getPlantTierConfig(6);
+    const active = getCachedPlantParts("flower", 6, forest, tierConfig, true);
+    const inactive = getCachedPlantParts("flower", 6, forest, tierConfig, false);
+    expect(active).not.toBe(inactive);
+  });
+
+  it("matches buildPlantParts' output for a fresh key", () => {
+    const ocean = getAllPalettes().find((p) => p.name === "Ocean")!;
+    const tierConfig = getPlantTierConfig(3);
+    expect(getCachedPlantParts("cactus", 3, ocean, tierConfig)).toEqual(
+      buildPlantParts("cactus", 3, ocean, tierConfig)
+    );
+  });
+});
+
+describe("maxHorizontalExtent", () => {
+  it("grows with tier, the basis for ticket 02's tile sizing", () => {
+    const forest = getAllPalettes().find((p) => p.name === "Forest")!;
+    for (const archetype of FARM_ARCHETYPE_ORDER) {
+      const small = maxHorizontalExtent(buildArchetypeParts(archetype, 1, forest, getPlantTierConfig(1)));
+      const large = maxHorizontalExtent(buildArchetypeParts(archetype, 9, forest, getPlantTierConfig(9)));
+      expect(large).toBeGreaterThanOrEqual(small);
+      expect(large).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/farm-geometry.ts
+++ b/src/lib/farm-geometry.ts
@@ -1,0 +1,505 @@
+import type { PlantPalette, PlantSpecies } from "@/lib/plant-variants";
+import type { PlantTier, PlantTierConfig } from "@/lib/streak-milestones";
+
+/**
+ * The 22 SVG species collapse into 8 archetypes by silhouette family — decided
+ * in wayfinder ticket 09 after five spike revisions. pumpkin-vine has no clean
+ * home (its real design has no vertical stem, unlike every archetype here) and
+ * defaults to Mound as the closest fit; flagged there, not silently assumed.
+ */
+export type FarmArchetype =
+  | "bloom"
+  | "column"
+  | "mound"
+  | "canopy"
+  | "frond"
+  | "mushroom"
+  | "topiary"
+  | "flytrap";
+
+const SPECIES_TO_ARCHETYPE: Record<PlantSpecies, FarmArchetype> = {
+  flower: "bloom",
+  tulip: "bloom",
+  sunflower: "bloom",
+  orchid: "bloom",
+  cactus: "column",
+  bamboo: "column",
+  pine: "column",
+  succulent: "mound",
+  clover: "mound",
+  grass: "mound",
+  strawberry: "mound",
+  "pumpkin-vine": "mound", // flagged in ticket 09 — no vertical stem in its real design
+  tree: "canopy",
+  palm: "canopy",
+  bonsai: "canopy",
+  fern: "frond",
+  vine: "frond",
+  coral: "frond",
+  lotus: "frond",
+  mushroom: "mushroom",
+  topiary: "topiary",
+  flytrap: "flytrap",
+};
+
+export function archetypeForSpecies(species: PlantSpecies): FarmArchetype {
+  return SPECIES_TO_ARCHETYPE[species] ?? "bloom";
+}
+
+export type FarmPartKind = "cylinder" | "sphere" | "box" | "torus";
+
+export interface FarmPart {
+  kind: FarmPartKind;
+  /** cylinder: [radiusTop, radiusBottom, height, radialSegments]; sphere: [radius, widthSegments, heightSegments]; box: [width, height, depth] */
+  args: readonly number[];
+  /** Local position — relative to `pivot` when set, otherwise world space. */
+  position: [number, number, number];
+  rotation?: [number, number, number];
+  scale?: [number, number, number];
+  color: string;
+  /**
+   * three.js rotates a mesh around its own geometric center, not an arbitrary
+   * point — so a part that needs to hinge from its base (a leaf swinging out
+   * from the stem, a jaw opening from its hinge edge) can't just carry its own
+   * rotation. `pivot` describes a wrapper group at a fixed world point and
+   * rotation; `position`/`rotation` above then place the mesh *inside* that
+   * group, so the rotation visibly pivots from the group's origin instead of
+   * the mesh's own center.
+   */
+  pivot?: { position: [number, number, number]; rotation: [number, number, number] };
+}
+
+function cyl(rTop: number, rBottom: number, height: number, x: number, y: number, z: number, color: string, segments = 8): FarmPart {
+  return { kind: "cylinder", args: [rTop, rBottom, height, segments], position: [x, y, z], color };
+}
+function sph(radius: number, x: number, y: number, z: number, color: string, scale?: [number, number, number], widthSeg = 8, heightSeg = 6): FarmPart {
+  return { kind: "sphere", args: [radius, widthSeg, heightSeg], position: [x, y, z], color, scale };
+}
+
+const POT_TOP_Y = 2.6;
+
+// Matches the real 2D pot's face exactly (streak-components.tsx: two eyes, a
+// smile arc, blush cheeks) — only drawn when active, same gating as the 2D
+// version. Placed on the pot's +Z face; the pot is symmetric so any fixed
+// viewing angle works as well as the 2D art's single fixed front view did.
+function potFaceParts(outlineColor: string): FarmPart[] {
+  const z = 2.95;
+  return [
+    sph(0.28, -0.6, 1.05, z, outlineColor, undefined, 4, 3),
+    sph(0.28, 0.6, 1.05, z, outlineColor, undefined, 4, 3),
+    {
+      kind: "torus",
+      args: [0.75, 0.09, 6, 10, (Math.PI * 2) / 3],
+      position: [0, 0.7, z],
+      rotation: [0, 0, (210 * Math.PI) / 180],
+      color: outlineColor,
+    },
+    sph(0.55, -1.4, 0.85, z - 0.05, "#f4a6c1", [1, 1, 0.4]),
+    sph(0.55, 1.4, 0.85, z - 0.05, "#f4a6c1", [1, 1, 0.4]),
+  ];
+}
+
+function potParts(pal: PlantPalette): FarmPart[] {
+  const parts: FarmPart[] = [
+    cyl(3.2, 2.6, 2.2, 0, 1.1, 0, pal.pot),
+    cyl(2.9, 2.9, 0.4, 0, 2.4, 0, pal.soil),
+  ];
+  const active = pal.name !== "Inactive";
+  if (active) parts.push(...potFaceParts("#3d3d3d"));
+  return parts;
+}
+function seedPart(pal: PlantPalette): FarmPart {
+  return sph(0.55, 0, POT_TOP_Y + 0.4, 0, pal.stem, undefined, 6, 4);
+}
+
+function ringAccents(count: number, radius: number, y: number, size: number, color: string): FarmPart[] {
+  const out: FarmPart[] = [];
+  for (let i = 0; i < count; i++) {
+    const a = (i / count) * Math.PI * 2;
+    out.push(sph(size, radius * Math.cos(a), y, radius * Math.sin(a), color, undefined, 4, 3));
+  }
+  return out;
+}
+
+/**
+ * A single straight cylinder topped with one sphere read as exactly what you'd
+ * expect once it was tall enough — a real proportions bug, not a taste call.
+ * Splitting the stem into offset segments kills that reading. Verified in the
+ * spike (https://claude.ai/code/artifact/c78b6a76-bbc7-445a-8efd-f327213f1a6b)
+ * across every archetype/tier/palette combination before this port.
+ */
+function bentStem(rTop: number, rBottom: number, height: number, color: string, bend: number): { parts: FarmPart[]; topX: number } {
+  const segCount = 3;
+  const segH = height / segCount;
+  const xs = [0];
+  for (let i = 1; i <= segCount; i++) xs.push(Math.sin((i / segCount) * Math.PI * 0.65) * bend * height);
+  const parts: FarmPart[] = [];
+  let y = 0;
+  for (let s = 0; s < segCount; s++) {
+    const rT = rBottom + (rTop - rBottom) * ((s + 1) / segCount);
+    const rB = rBottom + (rTop - rBottom) * (s / segCount);
+    parts.push(cyl(rT, rB, segH, (xs[s] + xs[s + 1]) / 2, y + segH / 2, 0, color));
+    y += segH;
+  }
+  return { parts, topX: xs[segCount] };
+}
+
+function clusterBlob(count: number, spreadR: number, blobR: number, y: number, color: string, seed: number): FarmPart[] {
+  const out: FarmPart[] = [];
+  for (let i = 0; i < count; i++) {
+    const yFrac = count > 1 ? 1 - (i / (count - 1)) * 2 : 0;
+    const ringR = Math.sqrt(Math.max(0, 1 - yFrac * yFrac));
+    const theta = i * 2.399963 + seed;
+    const cx = Math.cos(theta) * ringR * spreadR;
+    const cz = Math.sin(theta) * ringR * spreadR;
+    const cy = yFrac * spreadR * 0.7;
+    const r = blobR * (0.75 + hash(i * 3.3 + seed) * 0.35);
+    out.push(sph(r, cx, y + cy, cz, color, [1, 0.82, 1]));
+  }
+  return out;
+}
+
+function hash(n: number): number {
+  const x = Math.sin(n) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+function sideLeaf(y: number, angle: number, tilt: number, len: number, color: string): FarmPart {
+  return {
+    kind: "box",
+    args: [0.2, len, 0.5],
+    position: [0, len / 2, 0], // base at the pivot, extending outward
+    color,
+    pivot: { position: [0, y, 0], rotation: [0, angle, tilt] },
+  };
+}
+
+interface ArchetypeMeta {
+  hasFlower: boolean;
+  hasFruit: boolean;
+}
+
+type ArchetypeBuilder = (tier: PlantTier, pal: PlantPalette, meta: ArchetypeMeta) => FarmPart[];
+
+const bloom: ArchetypeBuilder = (tier, pal, meta) => {
+  const parts = potParts(pal);
+  if (tier === 0) return [...parts, seedPart(pal)];
+  const stemH = 1 + tier * 0.8;
+  const stem = bentStem(0.42, 0.32, stemH, pal.stem, 0.16);
+  parts.push(...stem.parts.map((p) => offsetY(p, POT_TOP_Y)));
+  if (tier >= 2) {
+    parts.push(sideLeaf(POT_TOP_Y + stemH * 0.4, 0.6, 1.0, 0.9 + tier * 0.08, pal.leaf));
+    parts.push(sideLeaf(POT_TOP_Y + stemH * 0.4, 0.6 + Math.PI, -1.0, 0.9 + tier * 0.08, pal.leaf));
+  }
+  if (tier >= 4) {
+    parts.push(sideLeaf(POT_TOP_Y + stemH * 0.7, 2.3, 1.05, 0.7 + tier * 0.06, pal.leaf));
+    parts.push(sideLeaf(POT_TOP_Y + stemH * 0.7, 2.3 + Math.PI, -1.05, 0.7 + tier * 0.06, pal.leaf));
+  }
+  const canR = 0.85 + tier * 0.22;
+  const canY = POT_TOP_Y + stemH + canR * 0.5;
+  const topX = stem.topX;
+  parts.push(...clusterBlob(4, canR * 0.65, canR * 0.6, canY, pal.leaf, tier).map((p) => offsetX(p, topX)));
+  if (meta.hasFlower) parts.push(...ringAccents(5, canR * 0.85, canY + canR * 0.35, 0.4, pal.flower).map((p) => offsetX(p, topX)));
+  if (meta.hasFruit) parts.push(...ringAccents(3, canR * 0.75, canY - canR * 0.35, 0.36, pal.fruit).map((p) => offsetX(p, topX)));
+  return parts;
+};
+
+const column: ArchetypeBuilder = (tier, pal, meta) => {
+  const parts = potParts(pal);
+  if (tier === 0) return [...parts, seedPart(pal)];
+  const segments = Math.min(1 + Math.floor(tier / 1.4), 6);
+  const segH = 1.3;
+  let y = POT_TOP_Y;
+  for (let i = 0; i < segments; i++) {
+    const rTop = 0.75 - i * 0.05;
+    const rBot = 0.85 - i * 0.05;
+    parts.push(cyl(rTop, rBot, segH, 0, y + segH / 2, 0, pal.stem));
+    y += segH * 0.92;
+  }
+  if (meta.hasFlower) parts.push(sph(0.55, 0, y + 0.2, 0, pal.flower, undefined, 6, 4));
+  if (meta.hasFruit) parts.push(...ringAccents(2, 0.85, y - segH * 0.6, 0.4, pal.fruit));
+  return parts;
+};
+
+const mound: ArchetypeBuilder = (tier, pal, meta) => {
+  const parts = potParts(pal);
+  if (tier === 0) return [...parts, seedPart(pal)];
+  const count = Math.min(3 + tier, 11);
+  for (let i = 0; i < count; i++) {
+    const a = (i / count) * Math.PI * 2 + i * 0.7;
+    // Blob radius cycled on i%3 alone (no tier term) meant Mound's silhouette
+    // spread outward with tier but never grew taller — every other archetype
+    // visibly gains height, so a flat one broke the farm's growth language.
+    // The +tier*0.03 keeps Mound "low and wide" (much less height gain than
+    // Bloom/Canopy) while still growing, verified in farm-geometry.test.ts.
+    const rr = 0.55 + (i % 3) * 0.15 + tier * 0.03;
+    const dist = 0.6 + tier * 0.09;
+    parts.push(sph(rr, dist * Math.cos(a), POT_TOP_Y + 0.5 + rr * 0.4, dist * Math.sin(a), pal.leaf, undefined, 6, 4));
+  }
+  if (meta.hasFlower) parts.push(...ringAccents(4, 0.9, POT_TOP_Y + 1.3, 0.35, pal.flower));
+  if (meta.hasFruit) parts.push(...ringAccents(3, 1.1, POT_TOP_Y + 0.3, 0.32, pal.fruit));
+  return parts;
+};
+
+const canopy: ArchetypeBuilder = (tier, pal, meta) => {
+  const parts = potParts(pal);
+  if (tier === 0) return [...parts, seedPart(pal)];
+  const trunkH = 1.5 + tier * 0.7;
+  const trunk = bentStem(0.65, 0.5, trunkH, pal.stem, 0.1);
+  parts.push(...trunk.parts.map((p) => offsetY(p, POT_TOP_Y)));
+  const crownR = 1.2 + tier * 0.3;
+  const topY = POT_TOP_Y + trunkH + crownR * 0.4;
+  const topX = trunk.topX;
+  // Three short angled limbs bridge the bare trunk into the crown, so the
+  // foliage reads as growing off branches rather than stuck on a stick.
+  const branchY = topY - crownR * 0.35;
+  const branchLen = crownR * 0.5;
+  for (let i = 0; i < 3; i++) {
+    const angle = 0.9 + i * ((Math.PI * 2) / 3);
+    parts.push({
+      kind: "cylinder",
+      args: [0.08, 0.16, branchLen, 6],
+      position: [0, branchLen / 2, 0],
+      color: pal.stem,
+      pivot: { position: [topX, branchY, 0], rotation: [0, angle, 1.1] },
+    });
+  }
+  // Two size scales of foliage clumps read as real clustered leaves instead
+  // of one big blob — a large outer layer plus a denser inner layer.
+  parts.push(...clusterBlob(8, crownR * 0.7, crownR * 0.5, topY, pal.leaf, tier + 5).map((p) => offsetX(p, topX)));
+  parts.push(...clusterBlob(5, crownR * 0.4, crownR * 0.42, topY - crownR * 0.1, pal.leaf, tier + 17).map((p) => offsetX(p, topX)));
+  if (meta.hasFlower) parts.push(...ringAccents(4, crownR * 0.85, topY + crownR * 0.4, 0.35, pal.flower).map((p) => offsetX(p, topX)));
+  if (meta.hasFruit) parts.push(...ringAccents(4, crownR * 0.9, topY - crownR * 0.5, 0.32, pal.fruit).map((p) => offsetX(p, topX)));
+  return parts;
+};
+
+const frond: ArchetypeBuilder = (tier, pal, meta) => {
+  const parts = potParts(pal);
+  if (tier === 0) return [...parts, seedPart(pal)];
+  const count = Math.min(3 + tier, 10);
+  const bladeLen = 1.5 + tier * 0.6;
+  for (let i = 0; i < count; i++) {
+    const tilt = -0.55 + (i % 2) * 0.1;
+    const angle = (i / count) * Math.PI * 2;
+    parts.push({
+      kind: "box",
+      args: [0.3, bladeLen, 0.1],
+      position: [0, bladeLen / 2, 0],
+      color: pal.leaf,
+      pivot: { position: [0, POT_TOP_Y, 0], rotation: [0, angle, tilt] },
+    });
+  }
+  if (meta.hasFlower) parts.push(sph(0.4, 0, POT_TOP_Y + bladeLen * 0.7, 0, pal.flower, undefined, 6, 4));
+  return parts;
+};
+
+const mushroom: ArchetypeBuilder = (tier, pal, meta) => {
+  const parts = potParts(pal);
+  if (tier === 0) return [...parts, seedPart(pal)];
+  const stalkH = 1 + tier * 0.65;
+  const stalk = bentStem(0.42, 0.55, stalkH, "#f3e9d8", 0.06);
+  parts.push(...stalk.parts.map((p) => offsetY(p, POT_TOP_Y)));
+  const capR = 1.1 + tier * 0.4;
+  const topX = stalk.topX;
+  parts.push(sph(capR, topX, POT_TOP_Y + stalkH + capR * 0.1, 0, pal.leaf, [1, 0.42, 1], 8, 5));
+  if (meta.hasFlower) parts.push(...ringAccents(5, capR * 0.65, POT_TOP_Y + stalkH + capR * 0.25, 0.22, pal.flower).map((p) => offsetX(p, topX)));
+  if (meta.hasFruit) parts.push(...ringAccents(3, 0.7, POT_TOP_Y + 0.3, 0.3, pal.fruit));
+  return parts;
+};
+
+const topiary: ArchetypeBuilder = (tier, pal, meta) => {
+  const parts = potParts(pal);
+  if (tier === 0) return [...parts, seedPart(pal)];
+  const stickH = 1.2 + tier * 0.65;
+  const stick = bentStem(0.32, 0.4, stickH, pal.stem, 0.14);
+  parts.push(...stick.parts.map((p) => offsetY(p, POT_TOP_Y)));
+  const ballR = 0.95 + tier * 0.26;
+  const ballY = POT_TOP_Y + stickH + ballR * 0.55;
+  const topX = stick.topX;
+  parts.push(...clusterBlob(6, ballR * 0.55, ballR * 0.62, ballY, pal.leaf, tier + 11).map((p) => offsetX(p, topX)));
+  if (meta.hasFlower) parts.push(...ringAccents(6, ballR * 0.9, ballY, 0.28, pal.flower).map((p) => offsetX(p, topX)));
+  if (meta.hasFruit) parts.push(...ringAccents(4, ballR * 0.7, ballY - ballR * 0.5, 0.26, pal.fruit).map((p) => offsetX(p, topX)));
+  return parts;
+};
+
+const flytrap: ArchetypeBuilder = (tier, pal, meta) => {
+  const parts = potParts(pal);
+  if (tier === 0) return [...parts, seedPart(pal)];
+  const stalkH = 0.8 + tier * 0.5;
+  parts.push(cyl(0.35, 0.4, stalkH, 0, POT_TOP_Y + stalkH / 2, 0, pal.stem));
+  const trapCount = Math.min(1 + Math.floor(tier / 2), 4);
+  const topY = POT_TOP_Y + stalkH;
+  for (let i = 0; i < trapCount; i++) {
+    const angle = trapCount > 1 ? (i / trapCount) * Math.PI * 2 : 0;
+    // Each jaw half hinges from x=0 (the pivot) and opens outward to x=±1 —
+    // the pivot's own Y-rotation sweeps the whole hinged pair to face `angle`,
+    // so the local offset here must stay un-rotated, not pre-multiplied by
+    // cos/sin (that would double-apply the sweep).
+    parts.push({
+      kind: "box",
+      args: [1.0, 0.14, 0.6],
+      position: [0.5, 0, 0],
+      color: pal.leaf,
+      pivot: { position: [0, topY, 0], rotation: [0, angle, 0.5] },
+    });
+    parts.push({
+      kind: "box",
+      args: [1.0, 0.14, 0.6],
+      position: [-0.5, 0, 0],
+      color: pal.leaf,
+      pivot: { position: [0, topY, 0], rotation: [0, angle, -0.5] },
+    });
+    if (meta.hasFlower) parts.push(sph(0.18, 0.4 * Math.cos(angle), topY, 0.4 * Math.sin(angle), pal.flower, undefined, 4, 3));
+  }
+  return parts;
+};
+
+const ARCHETYPE_BUILDERS: Record<FarmArchetype, ArchetypeBuilder> = {
+  bloom,
+  column,
+  mound,
+  canopy,
+  frond,
+  mushroom,
+  topiary,
+  flytrap,
+};
+
+export const FARM_ARCHETYPE_ORDER: FarmArchetype[] = [
+  "bloom",
+  "column",
+  "mound",
+  "canopy",
+  "frond",
+  "mushroom",
+  "topiary",
+  "flytrap",
+];
+
+function offsetY(part: FarmPart, dy: number): FarmPart {
+  return { ...part, position: [part.position[0], part.position[1] + dy, part.position[2]] };
+}
+function offsetX(part: FarmPart, dx: number): FarmPart {
+  return { ...part, position: [part.position[0] + dx, part.position[1], part.position[2]] };
+}
+
+/**
+ * Matches `SeedlingPlant`'s exact grey fallback when a learner's streak has
+ * lapsed (`active={false}`) — shape and tier stay the same, only color drops
+ * to grey. Same values as streak-components.tsx's inline fallbacks.
+ */
+const INACTIVE_PALETTE: PlantPalette = {
+  name: "Inactive",
+  stem: "#a1a1aa",
+  leaf: "#d4d4d8",
+  flower: "#71717a",
+  fruit: "#71717a",
+  pot: "#9c8b7e",
+  soil: "#6b5b4e",
+  glow: "#a1a1aa",
+};
+
+export function buildArchetypeParts(archetype: FarmArchetype, tier: PlantTier, palette: PlantPalette, tierConfig: PlantTierConfig, active = true): FarmPart[] {
+  const builder = ARCHETYPE_BUILDERS[archetype];
+  return builder(tier, active ? palette : INACTIVE_PALETTE, { hasFlower: tierConfig.hasFlower, hasFruit: tierConfig.hasFruit });
+}
+
+export function buildPlantParts(species: PlantSpecies, tier: PlantTier, palette: PlantPalette, tierConfig: PlantTierConfig, active = true): FarmPart[] {
+  return buildArchetypeParts(archetypeForSpecies(species), tier, palette, tierConfig, active);
+}
+
+/**
+ * Ticket 04's cache: keyed on `(archetype, tier, paletteName)`, not species or
+ * userId — geometry is a pure function of those three things, so two learners
+ * with the same archetype/tier/palette combo share one cached entry. Species
+ * is deliberately excluded from the key too: two species mapping to the same
+ * archetype (e.g. "flower" and "tulip", both Bloom) produce identical parts,
+ * so keying on species would cache the same geometry twice for no reason.
+ * There is no staleness to invalidate — a tier or palette change just looks up
+ * a different key, and the combination space is small enough (8 archetypes ×
+ * 10 tiers × ~16 palettes ≈ 1,280 entries, each a few hundred triangles) to
+ * keep every entry forever with no eviction policy.
+ */
+const partsCache = new Map<string, FarmPart[]>();
+export function getCachedPlantParts(species: PlantSpecies, tier: PlantTier, palette: PlantPalette, tierConfig: PlantTierConfig, active = true): FarmPart[] {
+  const archetype = archetypeForSpecies(species);
+  const key = `${archetype}:${tier}:${active ? palette.name : "inactive"}`;
+  const cached = partsCache.get(key);
+  if (cached) return cached;
+  const parts = buildArchetypeParts(archetype, tier, palette, tierConfig, active);
+  partsCache.set(key, parts);
+  return parts;
+}
+
+/** Applies a three.js-style Euler rotation (default 'XYZ' order, i.e. the
+ * point is rotated Z first, then Y, then X) to a local point. Only used for
+ * pivoted parts, whose rotation is never around their own center. */
+function applyEulerXYZ(p: [number, number, number], rotation: [number, number, number]): [number, number, number] {
+  const [rx, ry, rz] = rotation;
+  let [x, y, z] = p;
+  if (rz) {
+    const c = Math.cos(rz), s = Math.sin(rz);
+    [x, y] = [x * c - y * s, x * s + y * c];
+  }
+  if (ry) {
+    const c = Math.cos(ry), s = Math.sin(ry);
+    [x, z] = [x * c + z * s, -x * s + z * c];
+  }
+  if (rx) {
+    const c = Math.cos(rx), s = Math.sin(rx);
+    [y, z] = [y * c - z * s, y * s + z * c];
+  }
+  return [x, y, z];
+}
+
+/** The world-space points worth checking for height/extent purposes: a plain
+ * part's own position, or — for a pivoted part like a hinged leaf — both ends
+ * of its long axis rotated through the pivot, since the rotation can swing
+ * either end higher or wider than the part's local center alone would suggest. */
+function worldSamplePoints(part: FarmPart): Array<[number, number, number]> {
+  if (!part.pivot) return [[part.position[0], part.position[1], part.position[2]]];
+  const halfExtent = part.kind === "cylinder" ? part.args[2] / 2 : part.kind === "box" ? part.args[1] / 2 : part.args[0];
+  const scaleY = part.scale?.[1] ?? 1;
+  const ends: Array<[number, number, number]> = [
+    [part.position[0], part.position[1] - halfExtent * scaleY, part.position[2]],
+    [part.position[0], part.position[1] + halfExtent * scaleY, part.position[2]],
+  ];
+  return ends.map((p) => {
+    const [rx, ry, rz] = applyEulerXYZ(p, part.pivot!.rotation);
+    return [rx + part.pivot!.position[0], ry + part.pivot!.position[1], rz + part.pivot!.position[2]];
+  });
+}
+
+/** Real max height of a generated part set — used for the aura anchor and the
+ * tile hit-box in the field. Ticket 09 found a shared per-tier height formula
+ * floated the aura above short/wide archetypes like Mound; this measures the
+ * actual mesh instead of guessing. */
+export function maxPartHeight(parts: FarmPart[]): number {
+  let maxY = 0;
+  for (const part of parts) {
+    const scaleY = part.scale?.[1] ?? 1;
+    const halfExtent = part.pivot ? 0 : part.kind === "cylinder" ? part.args[2] / 2 : part.kind === "box" ? part.args[1] / 2 : part.args[0];
+    for (const [, y] of worldSamplePoints(part)) {
+      const top = y + halfExtent * scaleY;
+      if (top > maxY) maxY = top;
+    }
+  }
+  return maxY;
+}
+
+/** The widest horizontal extent across every archetype at tier 9 (the tallest,
+ * widest growth state) — used to size farm tiles so neighboring canopies can't
+ * interpenetrate. Ticket 02's answer: measure the real mesh, don't guess a
+ * constant. */
+export function maxHorizontalExtent(parts: FarmPart[]): number {
+  let maxR = 0;
+  for (const part of parts) {
+    const scaleXZ = Math.max(part.scale?.[0] ?? 1, part.scale?.[2] ?? 1);
+    const radius = part.kind === "cylinder" ? Math.max(part.args[0], part.args[1]) : part.kind === "box" ? Math.max(part.args[0], part.args[2]) / 2 : part.args[0];
+    for (const [x, , z] of worldSamplePoints(part)) {
+      const r = Math.hypot(x, z) + radius * scaleXZ;
+      if (r > maxR) maxR = r;
+    }
+  }
+  return maxR;
+}

--- a/src/lib/farm-layout.test.ts
+++ b/src/lib/farm-layout.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { getPlantTierConfig, type PlantTier } from "@/lib/streak-milestones";
+import {
+  computeTileSize,
+  tilePositionsForCount,
+  tileCenter,
+  leastOccludingRotationStep,
+  gridDimensionsForCount,
+  auraSpecForTier,
+  buildParticleDefs,
+  isRisingParticle,
+  GRID_COLS,
+  GRID_ROWS,
+} from "@/lib/farm-layout";
+
+describe("computeTileSize — ticket 02, measured from real geometry", () => {
+  it("returns a positive, finite, memoized value", () => {
+    const a = computeTileSize();
+    const b = computeTileSize();
+    expect(a).toBeGreaterThan(0);
+    expect(Number.isFinite(a)).toBe(true);
+    expect(a).toBe(b); // memoized, not recomputed
+  });
+});
+
+describe("tilePositionsForCount — ticket 10's verified fill order", () => {
+  it("fills the 4 corners first", () => {
+    const positions = tilePositionsForCount(4);
+    const corners = [
+      { col: 0, row: 0 }, { col: 2, row: 0 }, { col: 0, row: 2 }, { col: 2, row: 2 },
+    ];
+    expect(positions).toEqual(corners);
+  });
+
+  it("puts the center last, only reached past 8 members", () => {
+    const eight = tilePositionsForCount(8);
+    const nine = tilePositionsForCount(9);
+    expect(eight).not.toContainEqual({ col: 1, row: 1 });
+    expect(nine).toContainEqual({ col: 1, row: 1 });
+  });
+
+  it("caps at the 3×3 grid's 9 tiles", () => {
+    expect(tilePositionsForCount(20).length).toBe(GRID_COLS * GRID_ROWS);
+  });
+
+  it("never places two members on the same tile", () => {
+    const positions = tilePositionsForCount(9);
+    const keys = new Set(positions.map((p) => `${p.col},${p.row}`));
+    expect(keys.size).toBe(9);
+  });
+});
+
+describe("gridDimensionsForCount — cohort field scaling", () => {
+  it("stays the tuned 3×3 for a genmate-group-sized count", () => {
+    expect(gridDimensionsForCount(5)).toEqual({ cols: GRID_COLS, rows: GRID_ROWS });
+    expect(gridDimensionsForCount(9)).toEqual({ cols: GRID_COLS, rows: GRID_ROWS });
+  });
+
+  it("grows to fit a whole cohort instead of staying capped at 9", () => {
+    const { cols, rows } = gridDimensionsForCount(30);
+    expect(cols * rows).toBeGreaterThanOrEqual(30);
+  });
+});
+
+describe("tilePositionsForCount — a bigger grid doesn't silently drop members", () => {
+  it("returns one position per member when the grid is sized for the cohort", () => {
+    const count = 25;
+    const { cols, rows } = gridDimensionsForCount(count);
+    const positions = tilePositionsForCount(count, cols, rows);
+    expect(positions.length).toBe(count);
+    const keys = new Set(positions.map((p) => `${p.col},${p.row}`));
+    expect(keys.size).toBe(count);
+  });
+});
+
+describe("tileCenter — non-default grid dimensions", () => {
+  it("centers the grid around the origin for an arbitrary cols/rows", () => {
+    const tileSize = 2;
+    const cols = 5;
+    const rows = 4;
+    const first = tileCenter(0, 0, tileSize, cols, rows);
+    const last = tileCenter(cols - 1, rows - 1, tileSize, cols, rows);
+    expect(first.x).toBeCloseTo(-last.x, 10);
+    expect(first.z).toBeCloseTo(-last.z, 10);
+  });
+});
+
+describe("leastOccludingRotationStep — ticket 10", () => {
+  it("always returns a valid rotation step", () => {
+    const tileSize = computeTileSize();
+    for (let n = 1; n <= 9; n++) {
+      const step = leastOccludingRotationStep(tilePositionsForCount(n), tileSize);
+      expect(step).toBeGreaterThanOrEqual(0);
+      expect(step).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it("the verified 6-member corners-then-edges layout caps worst-case stacking at 2, never 3", () => {
+    const tileSize = computeTileSize();
+    const positions = tilePositionsForCount(6);
+    for (let step = 0; step < 4; step++) {
+      const yaw = Math.PI / 4 + step * (Math.PI / 2);
+      const columns = new Map<number, number>();
+      for (const pos of positions) {
+        const c = tileCenter(pos.col, pos.row, tileSize);
+        const x = c.x * Math.cos(yaw) + c.z * Math.sin(yaw);
+        const key = Math.round(x * 100);
+        columns.set(key, (columns.get(key) ?? 0) + 1);
+      }
+      expect(Math.max(...columns.values())).toBeLessThanOrEqual(2);
+    }
+  });
+});
+
+describe("auraSpecForTier", () => {
+  it("is null at tier 0 (growthGlow 'none')", () => {
+    expect(auraSpecForTier(0)).toBeNull();
+  });
+
+  it("matches the real PLANT_TIER_CONFIGS glow color/scale at every other tier", () => {
+    for (let tier = 1; tier <= 9; tier++) {
+      const spec = auraSpecForTier(tier as PlantTier);
+      const config = getPlantTierConfig(tier as PlantTier);
+      expect(spec).not.toBeNull();
+      expect(spec!.color).toBe(config.glowColor);
+      expect(spec!.scale).toBe(config.glowScale);
+    }
+  });
+});
+
+describe("buildParticleDefs — ports the real split verbatim", () => {
+  it("is empty at tier 0 (particleCount 0)", () => {
+    expect(buildParticleDefs(0)).toEqual([]);
+  });
+
+  it("matches the real pollen 35% / petal 30% / leaf 20% / light-remainder split at tier 9", () => {
+    const config = getPlantTierConfig(9);
+    const defs = buildParticleDefs(9);
+    expect(defs.length).toBe(config.particleCount);
+    const counts = { pollen: 0, petal: 0, leaf: 0, light: 0 };
+    defs.forEach((d) => counts[d.type]++);
+    expect(counts.pollen).toBe(Math.ceil(config.particleCount * 0.35));
+    expect(counts.petal).toBe(Math.ceil(config.particleCount * 0.3));
+    expect(counts.leaf).toBe(Math.ceil(config.particleCount * 0.2));
+    expect(counts.light).toBe(config.particleCount - counts.pollen - counts.petal - counts.leaf);
+  });
+
+  it("only produces types the tier's particleTypes actually gates in", () => {
+    // tier 1 ("sprout") only has ["pollen"] in the real config
+    const defs = buildParticleDefs(1);
+    expect(defs.every((d) => d.type === "pollen")).toBe(true);
+  });
+});
+
+describe("isRisingParticle", () => {
+  it("classifies pollen and light as rising, petal and leaf as falling — explicit direction, not the 2D component's all-rising default", () => {
+    expect(isRisingParticle("pollen")).toBe(true);
+    expect(isRisingParticle("light")).toBe(true);
+    expect(isRisingParticle("petal")).toBe(false);
+    expect(isRisingParticle("leaf")).toBe(false);
+  });
+});

--- a/src/lib/farm-layout.ts
+++ b/src/lib/farm-layout.ts
@@ -1,0 +1,218 @@
+import { getAllPalettes, type PlantPalette } from "@/lib/plant-variants";
+import { getPlantTierConfig, type GrowthGlowStyle, type PlantTier } from "@/lib/streak-milestones";
+import {
+  buildArchetypeParts,
+  maxHorizontalExtent,
+  FARM_ARCHETYPE_ORDER,
+  type FarmArchetype,
+} from "@/lib/farm-geometry";
+
+/** A 3×3 field covers a typical ~5-person genmate group with room — ticket 02. */
+export const GRID_COLS = 3;
+export const GRID_ROWS = 3;
+
+/**
+ * Tile pitch measured from the real geometry, not guessed: generate every
+ * archetype at tier 9 (the tallest, widest growth state) across every real
+ * palette, and size the tile from the widest result — ticket 02's answer,
+ * verified against a formula-based approach that under-sized tiles once tier
+ * scaling changed. Computed once per module load; the combination space is
+ * small (8 archetypes × ~16 palettes) so this is cheap.
+ */
+let cachedTileSize: number | null = null;
+export function computeTileSize(): number {
+  if (cachedTileSize !== null) return cachedTileSize;
+  const tier9Config = getPlantTierConfig(9);
+  const palettes = getAllPalettes();
+  let maxR = 0;
+  for (const archetype of FARM_ARCHETYPE_ORDER) {
+    for (const palette of palettes) {
+      const parts = buildArchetypeParts(archetype, 9, palette, tier9Config);
+      const r = maxHorizontalExtent(parts);
+      if (r > maxR) maxR = r;
+    }
+  }
+  cachedTileSize = maxR * 2 * 1.15;
+  return cachedTileSize;
+}
+
+export interface TilePosition {
+  col: number;
+  row: number;
+}
+
+/**
+ * Fill order matters more than the camera angle for avoiding diagonal-tile
+ * occlusion — ticket 10, verified by computation. An initial corners-and-
+ * center-first guess ("quincunx") looked natural but actually concentrated
+ * occlusion into a 3-way stack, since the center tile sits on both grid
+ * diagonals at once and is diagonally aligned with something at every 90°
+ * rotation step. Corners first, then edge-midpoints, center last (reached
+ * only past 8 members, which a genmate group never does) caps the worst-case
+ * screen-column stack at 2 instead of 3.
+ */
+const FILL_ORDER: TilePosition[] = [
+  { col: 0, row: 0 }, { col: 2, row: 0 }, { col: 0, row: 2 }, { col: 2, row: 2 }, // corners
+  { col: 1, row: 0 }, { col: 2, row: 1 }, { col: 1, row: 2 }, { col: 0, row: 1 }, // edges
+  { col: 1, row: 1 }, // center, last
+];
+
+/**
+ * The 3×3 field is sized for a genmate group, not a whole cohort — a cohort
+ * field (COHORT_FARM_SPEC.md's "one big field" option) needs the grid to
+ * actually grow with headcount instead of silently dropping anyone past the
+ * 9th tile. Defaults preserve the exact tuned 3×3 behavior for every
+ * existing caller (single genmate group, ≤9 members).
+ */
+export function gridDimensionsForCount(count: number): { cols: number; rows: number } {
+  if (count <= GRID_COLS * GRID_ROWS) return { cols: GRID_COLS, rows: GRID_ROWS };
+  const cols = Math.ceil(Math.sqrt(count));
+  const rows = Math.ceil(count / cols);
+  return { cols, rows };
+}
+
+/**
+ * The corners-then-edges-then-center order below is hand-tuned for exactly
+ * the 3×3 grid (ticket 10) — worth keeping for every genmate-group-sized
+ * field. A larger grid (a whole cohort) falls back to plain row-major fill:
+ * at that size some occlusion is expected and normal, like looking across an
+ * actual crowd, so it isn't worth re-deriving the occlusion-minimizing order
+ * for arbitrary dimensions.
+ */
+export function tilePositionsForCount(count: number, cols: number = GRID_COLS, rows: number = GRID_ROWS): TilePosition[] {
+  if (cols === GRID_COLS && rows === GRID_ROWS) {
+    return FILL_ORDER.slice(0, Math.min(count, FILL_ORDER.length));
+  }
+  const positions: TilePosition[] = [];
+  for (let row = 0; row < rows && positions.length < count; row++) {
+    for (let col = 0; col < cols && positions.length < count; col++) {
+      positions.push({ col, row });
+    }
+  }
+  return positions;
+}
+
+export function tileCenter(col: number, row: number, tileSize: number, cols: number = GRID_COLS, rows: number = GRID_ROWS): { x: number; z: number } {
+  return {
+    x: (col - (cols - 1) / 2) * tileSize,
+    z: (row - (rows - 1) / 2) * tileSize,
+  };
+}
+
+export const FIELD_PITCH = 0.52; // ~30°, classic isometric
+export const FIELD_YAW_BASE = Math.PI / 4; // 45°, the FFT diamond angle
+
+function rotateXZ(x: number, z: number, yaw: number): { x: number; z: number } {
+  return { x: x * Math.cos(yaw) + z * Math.sin(yaw), z: -x * Math.sin(yaw) + z * Math.cos(yaw) };
+}
+
+/**
+ * Auto-picks whichever of the 4 fixed rotation steps hides the fewest members
+ * at a glance — ticket 10. Still correct and worth keeping even though it ties
+ * for the spike's own symmetric 6-member layout; it helps for uneven group
+ * sizes where the 4 angles genuinely differ.
+ */
+export function leastOccludingRotationStep(
+  positions: TilePosition[],
+  tileSize: number,
+  cols: number = GRID_COLS,
+  rows: number = GRID_ROWS
+): number {
+  let bestStep = 0;
+  let bestExcess = Infinity;
+  for (let step = 0; step < 4; step++) {
+    const yaw = FIELD_YAW_BASE + step * (Math.PI / 2);
+    const columns = new Map<number, number>();
+    for (const pos of positions) {
+      const c = tileCenter(pos.col, pos.row, tileSize, cols, rows);
+      const { x } = rotateXZ(c.x, c.z, yaw);
+      const key = Math.round(x * 100);
+      columns.set(key, (columns.get(key) ?? 0) + 1);
+    }
+    const excess = Array.from(columns.values()).reduce((sum, n) => sum + Math.max(0, n - 1), 0);
+    if (excess < bestExcess) {
+      bestExcess = excess;
+      bestStep = step;
+    }
+  }
+  return bestStep;
+}
+
+interface AuraLayer {
+  mul: number;
+  alpha: number;
+}
+export interface AuraSpec {
+  color: string;
+  scale: number;
+  halo: [AuraLayer, AuraLayer];
+  core: AuraLayer;
+}
+
+const HALO_LAYERS: Record<Exclude<GrowthGlowStyle, "none">, [AuraLayer, AuraLayer]> = {
+  glow: [{ mul: 0.85, alpha: 0.3 }, { mul: 0.42, alpha: 0.42 }],
+  radiant: [{ mul: 1.05, alpha: 0.34 }, { mul: 0.5, alpha: 0.48 }],
+  bloom: [{ mul: 1.3, alpha: 0.38 }, { mul: 0.6, alpha: 0.52 }],
+  "bloom-ring": [{ mul: 1.3, alpha: 0.38 }, { mul: 0.6, alpha: 0.52 }], // not used by any real tier today; falls back to `bloom`'s layers
+  aurora: [{ mul: 1.7, alpha: 0.42 }, { mul: 0.75, alpha: 0.56 }],
+};
+const CORE_LAYER: Record<Exclude<GrowthGlowStyle, "none">, AuraLayer> = {
+  glow: { mul: 0.3, alpha: 0.55 },
+  radiant: { mul: 0.36, alpha: 0.62 },
+  bloom: { mul: 0.44, alpha: 0.68 },
+  "bloom-ring": { mul: 0.44, alpha: 0.68 },
+  aurora: { mul: 0.56, alpha: 0.75 },
+};
+
+export function auraSpecForTier(tier: PlantTier): AuraSpec | null {
+  const config = getPlantTierConfig(tier);
+  if (config.growthGlow === "none") return null;
+  return {
+    color: config.glowColor,
+    scale: config.glowScale,
+    halo: HALO_LAYERS[config.growthGlow],
+    core: CORE_LAYER[config.growthGlow],
+  };
+}
+
+export type ParticleType = "pollen" | "petal" | "leaf" | "light";
+export interface ParticleDef {
+  type: ParticleType;
+  seed: number;
+}
+
+/**
+ * Ports the real split from streak-components.tsx verbatim (pollen 35% / petal
+ * 30% / leaf 20% / light remainder of `particleCount`, gated by that tier's
+ * `particleTypes`) — but leaf and petal fall while pollen and light rise,
+ * unlike the 2D component's all-rising default. That direction was explicit,
+ * not a port bug.
+ */
+export function buildParticleDefs(tier: PlantTier): ParticleDef[] {
+  const config = getPlantTierConfig(tier);
+  const pc = config.particleCount;
+  const counts: Record<ParticleType, number> = {
+    pollen: Math.ceil(pc * 0.35),
+    petal: Math.ceil(pc * 0.3),
+    leaf: Math.ceil(pc * 0.2),
+    light: 0,
+  };
+  counts.light = pc - counts.pollen - counts.petal - counts.leaf;
+  const defs: ParticleDef[] = [];
+  (["pollen", "petal", "leaf", "light"] as ParticleType[]).forEach((type) => {
+    if (!config.particleTypes.includes(type)) return;
+    for (let i = 0; i < counts[type]; i++) defs.push({ type, seed: defs.length * 7.31 + i * 3.17 + 1 });
+  });
+  return defs;
+}
+
+export function isRisingParticle(type: ParticleType): boolean {
+  return type === "pollen" || type === "light";
+}
+
+export interface FarmMember {
+  id: string;
+  archetype: FarmArchetype;
+  tier: PlantTier;
+  palette: PlantPalette;
+}

--- a/src/lib/farm-terrain.test.ts
+++ b/src/lib/farm-terrain.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { terrainHeightAt, TERRAIN_MARGIN } from "@/lib/farm-terrain";
+
+const FLAT_HALF_W = 6;
+const FLAT_HALF_D = 6;
+
+describe("terrainHeightAt", () => {
+  it("is exactly 0 at multiple points strictly inside the flat zone", () => {
+    const points: Array<[number, number]> = [
+      [0, 0],
+      [3, 3],
+      [-5.9, 5.9],
+      [FLAT_HALF_W, 0],
+      [0, FLAT_HALF_D],
+      [FLAT_HALF_W, FLAT_HALF_D],
+    ];
+    for (const [x, z] of points) {
+      expect(terrainHeightAt(x, z, FLAT_HALF_W, FLAT_HALF_D)).toBe(0);
+    }
+  });
+
+  it("is nonzero and bounded outside the flat zone", () => {
+    const points: Array<[number, number]> = [
+      [FLAT_HALF_W + 3, 0],
+      [0, FLAT_HALF_D + 4],
+      [FLAT_HALF_W + 2, FLAT_HALF_D + 2],
+      [-(FLAT_HALF_W + 3), 0],
+    ];
+    for (const [x, z] of points) {
+      const h = terrainHeightAt(x, z, FLAT_HALF_W, FLAT_HALF_D);
+      expect(h).toBeGreaterThan(0);
+      expect(h).toBeLessThanOrEqual(0.6);
+    }
+  });
+
+  it("has no sharp jump right at the flat-zone boundary", () => {
+    const atBoundary = terrainHeightAt(FLAT_HALF_W + 0.01, 0, FLAT_HALF_W, FLAT_HALF_D);
+    const farOut = terrainHeightAt(FLAT_HALF_W + 5, 0, FLAT_HALF_W, FLAT_HALF_D);
+    expect(atBoundary).toBeLessThan(0.05);
+    expect(atBoundary).toBeLessThan(farOut);
+  });
+
+  it("is deterministic — same inputs produce the same output", () => {
+    const a = terrainHeightAt(9, -4, FLAT_HALF_W, FLAT_HALF_D);
+    const b = terrainHeightAt(9, -4, FLAT_HALF_W, FLAT_HALF_D);
+    expect(a).toBe(b);
+  });
+
+  it("TERRAIN_MARGIN comfortably covers the background trees' max placement distance", () => {
+    // buildBackgroundTrees places trees up to ~2.6 units beyond the fence,
+    // which itself sits right at the flat-zone edge — TERRAIN_MARGIN must
+    // clear that plus the blend band itself.
+    expect(TERRAIN_MARGIN).toBeGreaterThan(2.6 + 2);
+  });
+});

--- a/src/lib/farm-terrain.ts
+++ b/src/lib/farm-terrain.ts
@@ -1,0 +1,44 @@
+/** How far the ground mesh extends past the tile footprint — large enough to
+ * comfortably cover `buildBackgroundTrees`' max placement distance (fence
+ * margin + tree margin, up to ~2.6 units beyond the fence) plus the blend
+ * band itself. */
+export const TERRAIN_MARGIN = 5;
+
+const BLEND_WIDTH = 2;
+const MAX_AMPLITUDE = 0.6;
+
+function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = Math.max(0, Math.min(1, (x - edge0) / (edge1 - edge0)));
+  return t * t * (3 - 2 * t);
+}
+
+function hash(n: number): number {
+  const x = Math.sin(n) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+/** Cheap layered-sine "hills" — same deterministic-noise style already used
+ * throughout `farm-geometry.ts`/`farm-decorations.ts`, no external noise lib. */
+function hillNoise(x: number, z: number): number {
+  const a = Math.sin(x * 0.35 + z * 0.2) * 0.5 + 0.5;
+  const b = Math.sin(x * 0.13 - z * 0.31 + 4.7) * 0.5 + 0.5;
+  const c = hash(Math.round(x * 3) * 12.9898 + Math.round(z * 3) * 78.233) - 0.5;
+  return a * 0.6 + b * 0.4 + c * 0.15;
+}
+
+/**
+ * `0` anywhere inside the tile footprint (the play surface tile-center math,
+ * occlusion ordering, `ContactShadows`, and the grass patch all assume flat
+ * ground there) — smoothstep-blended up to real rolling hills only in the
+ * decorative apron beyond it, where the fence and background trees already
+ * stand. Deterministic: same (x, z) always returns the same height.
+ */
+export function terrainHeightAt(x: number, z: number, flatHalfW: number, flatHalfD: number): number {
+  const distX = Math.max(0, Math.abs(x) - flatHalfW);
+  const distZ = Math.max(0, Math.abs(z) - flatHalfD);
+  const dist = Math.hypot(distX, distZ);
+  if (dist <= 0) return 0;
+  const blend = smoothstep(0, BLEND_WIDTH, dist);
+  const noise = Math.max(0, Math.min(1, (hillNoise(x, z) + 1) / 2));
+  return blend * noise * MAX_AMPLITUDE;
+}

--- a/src/lib/farm-textures.test.ts
+++ b/src/lib/farm-textures.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { getPartTexture, repeatForPart } from "@/lib/farm-textures";
+import type { FarmPart } from "@/lib/farm-geometry";
+
+// jsdom doesn't implement real canvas 2D (no `canvas` npm package installed,
+// same limitation the whole farm scene works around elsewhere) — stub just
+// the handful of CanvasRenderingContext2D members getPartTexture calls.
+function stub2dContext() {
+  return {
+    fillStyle: "",
+    globalAlpha: 1,
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe("getPartTexture", () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(stub2dContext());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the same cached texture instance for the same color", () => {
+    const a = getPartTexture("#5f8a3f");
+    const b = getPartTexture("#5f8a3f");
+    expect(a).not.toBeNull();
+    expect(a).toBe(b);
+  });
+
+  it("returns different instances for different colors", () => {
+    const a = getPartTexture("#5f8a3f");
+    const b = getPartTexture("#6b4a34");
+    expect(a).not.toBe(b);
+  });
+
+  it("falls back to null instead of throwing when canvas 2d is unavailable", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+    expect(() => getPartTexture("#123456")).not.toThrow();
+    expect(getPartTexture("#123456")).toBeNull();
+  });
+});
+
+describe("repeatForPart", () => {
+  it("gives a wide part a larger repeat than a thin one", () => {
+    const thinStem: FarmPart = { kind: "cylinder", args: [0.1, 0.1, 0.5, 8], position: [0, 0, 0], color: "#000" };
+    const widePot: FarmPart = { kind: "cylinder", args: [3.2, 2.6, 2.2, 8], position: [0, 0, 0], color: "#000" };
+    const [thinRepeat] = repeatForPart(thinStem);
+    const [wideRepeat] = repeatForPart(widePot);
+    expect(wideRepeat).toBeGreaterThan(thinRepeat);
+  });
+
+  it("always returns at least a 1x1 repeat", () => {
+    const tiny: FarmPart = { kind: "sphere", args: [0.05, 4, 3], position: [0, 0, 0], color: "#000" };
+    const [x, y] = repeatForPart(tiny);
+    expect(x).toBeGreaterThanOrEqual(1);
+    expect(y).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/lib/farm-textures.ts
+++ b/src/lib/farm-textures.ts
@@ -1,0 +1,123 @@
+import * as THREE from "three";
+import type { FarmPart } from "@/lib/farm-geometry";
+
+const TEXTURE_SIZE = 64;
+const SPECKLE_COUNT = 48;
+
+function hashString(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+function seededRandom(seed: number): () => number {
+  let s = seed % 233280;
+  return () => {
+    s = (s * 9301 + 49297) % 233280;
+    return s / 233280;
+  };
+}
+
+function shade(hex: string, amount: number): string {
+  const parsed = parseInt(hex.replace("#", ""), 16);
+  const clamp = (v: number) => Math.min(255, Math.max(0, v));
+  const r = clamp(((parsed >> 16) & 0xff) + amount);
+  const g = clamp(((parsed >> 8) & 0xff) + amount);
+  const b = clamp((parsed & 0xff) + amount);
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+/** `FarmPart.args` mixes spatial dimensions with mesh-quality integers
+ * (radialSegments, widthSegments...) that must never drive tiling density —
+ * a thin 8-segment stem and a wide 8-segment pot would otherwise tile
+ * identically because the segment count, not the radius, dominates `Math.max`. */
+function spatialDims(part: FarmPart): number[] {
+  switch (part.kind) {
+    case "cylinder":
+      return [part.args[0], part.args[1], part.args[2]];
+    case "sphere":
+      return [part.args[0]];
+    case "box":
+      return [part.args[0], part.args[1], part.args[2]];
+    case "torus":
+      return [part.args[0], part.args[1]];
+  }
+}
+
+/** Derives a repeat count from a part's own size so a thin stem doesn't
+ * stretch one grain blob over its whole length while a wide pot doesn't tile
+ * too densely — both ends of the archetype size range share one texture. */
+export function repeatForPart(part: FarmPart): [number, number] {
+  const scale = part.scale ?? [1, 1, 1];
+  const maxDim = Math.max(...spatialDims(part)) * Math.max(...scale);
+  const n = Math.max(1, Math.round(maxDim * 1.2));
+  return [n, n];
+}
+
+const textureCache = new Map<string, THREE.CanvasTexture | null>();
+
+/** A small procedural grain texture tinted to `hexColor` — every plant part
+ * uses the same generator, keyed only by its own resolved palette color, so
+ * bark/leaf/petal/pot all get texture instead of flat color without needing
+ * a separate pattern (and a `role` field) per surface type. */
+export function getPartTexture(hexColor: string): THREE.CanvasTexture | null {
+  const cached = textureCache.get(hexColor);
+  if (cached !== undefined) return cached;
+
+  let texture: THREE.CanvasTexture | null = null;
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = TEXTURE_SIZE;
+    canvas.height = TEXTURE_SIZE;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("2d context unavailable");
+
+    ctx.fillStyle = hexColor;
+    ctx.fillRect(0, 0, TEXTURE_SIZE, TEXTURE_SIZE);
+
+    const rand = seededRandom(hashString(hexColor));
+    for (let i = 0; i < SPECKLE_COUNT; i++) {
+      const lighter = rand() > 0.5;
+      ctx.fillStyle = shade(hexColor, lighter ? 28 : -28);
+      ctx.globalAlpha = 0.12 + rand() * 0.18;
+      const x = rand() * TEXTURE_SIZE;
+      const y = rand() * TEXTURE_SIZE;
+      const r = 1 + rand() * 2.5;
+      ctx.beginPath();
+      ctx.arc(x, y, r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+
+    texture = new THREE.CanvasTexture(canvas);
+    texture.wrapS = THREE.RepeatWrapping;
+    texture.wrapT = THREE.RepeatWrapping;
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } catch {
+    texture = null;
+  }
+
+  textureCache.set(hexColor, texture);
+  return texture;
+}
+
+const TOON_STEPS = 4;
+let toonGradientMap: THREE.DataTexture | null = null;
+
+/** A hard-stepped gradient for `meshToonMaterial` — flat color bands instead
+ * of smooth shading, the "toylike" cel-shaded look. One shared instance for
+ * the whole scene since the banding itself isn't a per-color choice. Built
+ * from a raw typed array rather than canvas so it also works in the rare
+ * case canvas 2D is unavailable (unlike `getPartTexture`, this has no
+ * meaningful color-image fallback to drop to). */
+export function getToonGradientMap(): THREE.DataTexture {
+  if (toonGradientMap) return toonGradientMap;
+  const data = new Uint8Array(TOON_STEPS);
+  for (let i = 0; i < TOON_STEPS; i++) data[i] = Math.round((i / (TOON_STEPS - 1)) * 255);
+  const tex = new THREE.DataTexture(data, TOON_STEPS, 1, THREE.RedFormat);
+  tex.minFilter = THREE.NearestFilter;
+  tex.magFilter = THREE.NearestFilter;
+  tex.needsUpdate = true;
+  toonGradientMap = tex;
+  return tex;
+}

--- a/src/lib/genmate-garden.ts
+++ b/src/lib/genmate-garden.ts
@@ -2,6 +2,7 @@ import { calculateStreakData, getDisplayStreak } from "@/hooks/use-streak-calcul
 import type { Reflection } from "@/hooks/use-reflections";
 import type { GenmateGardenMember } from "@/domain/types";
 import type { GardenMember } from "@/components/genmate-garden";
+import type { GenmateFieldMember } from "@/components/farm/GenmateField";
 import { getPlantVariant } from "@/lib/plant-variants";
 import { getPlantTier, getEffectivePlantDays } from "@/lib/streak-milestones";
 
@@ -37,4 +38,18 @@ export function mapGenmateMembers(members: GenmateGardenMember[]): GardenMember[
       growthPoints: m.growth_points ?? 0,
     };
   });
+}
+
+/** Adapts the 2D grid's `GardenMember`s into the 3D farm's member shape —
+ * same underlying data (`mapGenmateMembers`), no separate fetch or model. */
+export function toFarmMembers(members: GardenMember[]): GenmateFieldMember[] {
+  return members.map((m) => ({
+    id: m.user._id,
+    name: `${m.user.first_name ?? ""} ${m.user.last_name ?? ""}`.trim() || "Unknown learner",
+    species: m.variant.species,
+    tier: m.tier,
+    palette: m.variant.palette,
+    active: m.streakData.hasCurrentStreak,
+    displayStreakDays: m.displayStreak,
+  }));
 }

--- a/src/pages/CohortGenmateGardenPage.test.tsx
+++ b/src/pages/CohortGenmateGardenPage.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import CohortGenmateGardenPage from "./CohortGenmateGardenPage";
+import type { GenmateGardenMember, CohortGardenGroup } from "@/domain/types";
+
+vi.mock("@/lib/api", () => ({
+  getCohortGarden: vi.fn(),
+}));
+
+vi.mock("@/AuthContext", () => ({
+  useAuth: () => ({ userId: "current-user" }),
+}));
+
+vi.mock("@/UserDataContext", () => ({
+  useUserData: () => ({
+    userData: { fertilizer_balance: 3, cohort_number: 12 },
+    refetchUserData: vi.fn(),
+  }),
+}));
+
+vi.mock("@/application/services/fertilizerService", () => ({
+  fertilizerService: { gift: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import { getCohortGarden } from "@/lib/api";
+const mockedGetCohortGarden = vi.mocked(getCohortGarden);
+
+function member(overrides: Partial<GenmateGardenMember>): GenmateGardenMember {
+  return {
+    _id: "user-1",
+    first_name: "Alice",
+    last_name: "Smith",
+    cohort_number: 12,
+    genmate_group: "Garden Alpha",
+    reflection_dates: [],
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <CohortGenmateGardenPage />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("CohortGenmateGardenPage", () => {
+  beforeEach(() => {
+    mockedGetCohortGarden.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows every member across every group, including Unaffiliated, together on one field", async () => {
+    const groups: CohortGardenGroup[] = [
+      {
+        group_name: "Garden Alpha",
+        members: [
+          member({ _id: "user-1", first_name: "Alice" }),
+          member({ _id: "user-2", first_name: "Bob" }),
+        ],
+      },
+      {
+        group_name: "Unaffiliated",
+        members: [member({ _id: "user-3", first_name: "Carol", genmate_group: "" })],
+      },
+    ];
+    mockedGetCohortGarden.mockResolvedValue(groups);
+
+    renderPage();
+
+    expect(await screen.findByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.getByText("Carol")).toBeInTheDocument();
+    expect(screen.getByText("Cohort 12")).toBeInTheDocument();
+    expect(screen.getByText("3 members · avg 0.0 days")).toBeInTheDocument();
+  });
+
+  it("has no per-group tabs — there's nothing to switch between anymore", async () => {
+    const groups: CohortGardenGroup[] = [
+      { group_name: "Garden Alpha", members: [member({ _id: "user-1", first_name: "Alice" })] },
+      { group_name: "Garden Beta", members: [member({ _id: "user-2", first_name: "Dan", genmate_group: "Garden Beta" })] },
+    ];
+    mockedGetCohortGarden.mockResolvedValue(groups);
+
+    renderPage();
+
+    await screen.findByText("Alice");
+    expect(screen.getByText("Dan")).toBeInTheDocument();
+    expect(screen.queryByText("Garden Alpha")).not.toBeInTheDocument();
+    expect(screen.queryByText("Garden Beta")).not.toBeInTheDocument();
+  });
+
+  it("renders the empty state when the cohort has no members", async () => {
+    mockedGetCohortGarden.mockResolvedValue([]);
+
+    renderPage();
+
+    expect(
+      await screen.findByText("No one's in the cohort garden yet — check back once reflections start rolling in.")
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/CohortGenmateGardenPage.tsx
+++ b/src/pages/CohortGenmateGardenPage.tsx
@@ -1,0 +1,176 @@
+import React, { Suspense, useMemo, useState } from "react";
+import { useQuery } from "react-query";
+import { Sprout } from "lucide-react";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { SkeletonWarm } from "@/components/loading-skeleton";
+import { getCohortGarden } from "@/lib/api";
+import { mapGenmateMembers, toFarmMembers } from "@/lib/genmate-garden";
+import { PlantTile } from "@/components/genmate-garden";
+import { useWebglSupported } from "@/hooks/use-webgl-support";
+import { useUserData } from "@/UserDataContext";
+
+// three.js only loads once a learner flips to Farm for a group — same lazy
+// boundary as the genmate farm on LearnerGenmateGardenPage.
+const GenmateField = React.lazy(() =>
+  import("@/components/farm/GenmateField").then((mod) => ({ default: mod.GenmateField }))
+);
+
+type ViewMode = "grid" | "farm";
+
+/**
+ * The cohort-wide memory farm (COHORT_FARM_SPEC.md) — every genmate group in
+ * the learner's cohort, plus one "Unaffiliated" group for anyone without a
+ * genmate_group, flattened into one shared field instead of per-group tabs.
+ * The field itself scales its grid to headcount (`gridDimensionsForCount`)
+ * instead of the genmate-group-sized 3×3, so a whole cohort doesn't silently
+ * lose anyone past the 9th tile.
+ */
+const CohortGenmateGardenPage: React.FC = () => {
+  const { userData } = useUserData();
+  const cohortNumber = userData?.cohort_number ?? 0;
+
+  const { data, isLoading, isError, refetch } = useQuery(
+    ["cohortGarden", cohortNumber],
+    () => getCohortGarden(cohortNumber),
+    { enabled: cohortNumber > 0 }
+  );
+
+  const [view, setView] = useState<ViewMode>("grid");
+  const webglSupported = useWebglSupported();
+
+  const allMembersRaw = useMemo(() => (data ?? []).flatMap((g) => g.members), [data]);
+  const members = useMemo(() => mapGenmateMembers(allMembersRaw), [allMembersRaw]);
+  const farmMembers = useMemo(() => toFarmMembers(members), [members]);
+
+  const averageStreak =
+    members.length > 0
+      ? members.reduce((sum, m) => sum + m.displayStreak, 0) / members.length
+      : 0;
+
+  const handleFarmContextLost = () => {
+    setView("grid");
+    toast.error("3D view lost — showing the grid instead");
+  };
+
+  return (
+    <div className="container mx-auto py-10 space-y-6">
+      <div className="flex items-center gap-3">
+        <Sprout className="w-8 h-8 text-emerald-600 dark:text-emerald-400" />
+        <h1 className="text-3xl font-bold">Cohort Garden</h1>
+      </div>
+
+      <p className="text-muted-foreground max-w-2xl">
+        Every learner in your cohort, standing together, grown through reflection streaks — a
+        shared memory that keeps growing until the cohort wraps up. 🔥
+      </p>
+
+      {isLoading && (
+        <Card className="w-full">
+          <CardHeader>
+            <SkeletonWarm className="h-6 w-40" />
+            <SkeletonWarm className="h-4 w-64" />
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="flex flex-col items-center gap-2">
+                  <SkeletonWarm className="h-24 w-24 rounded-xl" />
+                  <SkeletonWarm className="h-3 w-16" />
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {isError && (
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle className="text-lg">Couldn't load the cohort garden</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Something went wrong while fetching the cohort garden. Try again.
+            </p>
+            <Button type="button" variant="outline" className="mt-4" onClick={() => refetch()}>
+              Try again
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && members.length === 0 && (
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle className="text-lg">
+              <Sprout className="mr-2 inline-block h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+              Cohort Garden
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              No one's in the cohort garden yet — check back once reflections start rolling in.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && members.length > 0 && (
+        <div className="flex flex-col gap-6">
+          <Card className="w-full">
+            <CardHeader className="pb-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <CardTitle className="text-base">Cohort {cohortNumber}</CardTitle>
+                <div className="flex items-center gap-3">
+                  <span className="text-xs font-medium text-muted-foreground tabular-nums">
+                    {members.length} members · avg {averageStreak.toFixed(1)} days
+                  </span>
+                  <Tabs value={view} onValueChange={(v) => setView(v as ViewMode)}>
+                    <TabsList>
+                      <TabsTrigger value="grid">Grid</TabsTrigger>
+                      {webglSupported ? (
+                        <TabsTrigger value="farm">Farm</TabsTrigger>
+                      ) : (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span>
+                                <TabsTrigger value="farm" disabled>
+                                  Farm
+                                </TabsTrigger>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>3D view isn't supported on this device</TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
+                    </TabsList>
+                  </Tabs>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {view === "grid" ? (
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+                  {members.map((member) => (
+                    <PlantTile key={member.user._id} member={member} />
+                  ))}
+                </div>
+              ) : (
+                <Suspense fallback={<SkeletonWarm className="aspect-[4/3] w-full rounded-xl" />}>
+                  <GenmateField members={farmMembers} onContextLost={handleFarmContextLost} />
+                </Suspense>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CohortGenmateGardenPage;

--- a/src/pages/LearnerGenmateGardenPage.test.tsx
+++ b/src/pages/LearnerGenmateGardenPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import LearnerGenmateGardenPage from "./LearnerGenmateGardenPage";
 import { calculateStreakData } from "@/hooks/use-streak-calculation";
@@ -79,9 +80,11 @@ function renderPage() {
     defaultOptions: { queries: { retry: false } },
   });
   return render(
-    <QueryClientProvider client={queryClient}>
-      <LearnerGenmateGardenPage />
-    </QueryClientProvider>
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <LearnerGenmateGardenPage />
+      </QueryClientProvider>
+    </MemoryRouter>
   );
 }
 

--- a/src/pages/LearnerGenmateGardenPage.tsx
+++ b/src/pages/LearnerGenmateGardenPage.tsx
@@ -1,12 +1,25 @@
-import React, { useMemo } from "react";
+import React, { Suspense, useMemo, useState } from "react";
 import { useQuery } from "react-query";
-import { Sprout } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Sprout, ArrowRight } from "lucide-react";
+import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { SkeletonWarm } from "@/components/loading-skeleton";
 import { getMyGenmateGarden } from "@/lib/api";
-import { mapGenmateMembers } from "@/lib/genmate-garden";
+import { mapGenmateMembers, toFarmMembers } from "@/lib/genmate-garden";
 import { PlantTile } from "@/components/genmate-garden";
+import { useWebglSupported } from "@/hooks/use-webgl-support";
+
+// three.js only loads once a learner actually flips to Farm — per the map's
+// standing fact, not bundled into the default garden page weight.
+const GenmateField = React.lazy(() =>
+  import("@/components/farm/GenmateField").then((mod) => ({ default: mod.GenmateField }))
+);
+
+type ViewMode = "grid" | "farm";
 
 const LearnerGenmateGardenPage: React.FC = () => {
   const { data, isLoading, isError, refetch } = useQuery(
@@ -15,22 +28,64 @@ const LearnerGenmateGardenPage: React.FC = () => {
   );
 
   const members = useMemo(() => mapGenmateMembers(data ?? []), [data]);
+  const farmMembers = useMemo(() => toFarmMembers(members), [members]);
+  const webglSupported = useWebglSupported();
+  // The grid stays the default view — ticket 02's placement decision.
+  const [view, setView] = useState<ViewMode>("grid");
 
   const averageStreak =
     members.length > 0
       ? members.reduce((sum, m) => sum + m.displayStreak, 0) / members.length
       : 0;
 
+  const handleFarmContextLost = () => {
+    setView("grid");
+    toast.error("3D view lost — showing the grid instead");
+  };
+
   return (
     <div className="container mx-auto py-10 space-y-6">
-      <div className="flex items-center gap-3">
-        <Sprout className="w-8 h-8 text-emerald-600 dark:text-emerald-400" />
-        <h1 className="text-3xl font-bold">Genmate Garden</h1>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Sprout className="w-8 h-8 text-emerald-600 dark:text-emerald-400" />
+          <h1 className="text-3xl font-bold">Genmate Garden</h1>
+        </div>
+        {!isLoading && !isError && members.length > 0 && (
+          <Tabs value={view} onValueChange={(v) => setView(v as ViewMode)}>
+            <TabsList>
+              <TabsTrigger value="grid">Grid</TabsTrigger>
+              {webglSupported ? (
+                <TabsTrigger value="farm">Farm</TabsTrigger>
+              ) : (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <TabsTrigger value="farm" disabled>
+                          Farm
+                        </TabsTrigger>
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>3D view isn't supported on this device</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
+            </TabsList>
+          </Tabs>
+        )}
       </div>
 
-      <p className="text-muted-foreground max-w-2xl">
-        Your genmate group, grown through reflection streaks. Cheer your genmates on as their plants grow! 🔥
-      </p>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-muted-foreground max-w-2xl">
+          Your genmate group, grown through reflection streaks. Cheer your genmates on as their plants grow! 🔥
+        </p>
+        <Button asChild variant="ghost" size="sm" className="gap-1">
+          <Link to="/learner/cohort-garden">
+            See your whole cohort
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </Button>
+      </div>
 
       {isLoading && (
         <Card className="w-full">
@@ -107,11 +162,19 @@ const LearnerGenmateGardenPage: React.FC = () => {
               </div>
             </CardHeader>
             <CardContent>
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-                {members.map((member) => (
-                  <PlantTile key={member.user._id} member={member} />
-                ))}
-              </div>
+              {view === "grid" ? (
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+                  {members.map((member) => (
+                    <PlantTile key={member.user._id} member={member} />
+                  ))}
+                </div>
+              ) : (
+                <Suspense
+                  fallback={<SkeletonWarm className="aspect-[4/3] w-full rounded-xl" />}
+                >
+                  <GenmateField members={farmMembers} onContextLost={handleFarmContextLost} />
+                </Suspense>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/src/pages/admin/AdminCohortFarmPage.test.tsx
+++ b/src/pages/admin/AdminCohortFarmPage.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AdminCohortFarmPage } from "./AdminCohortFarmPage";
+import type { GenmateGardenMember, CohortGardenGroup } from "@/domain/types";
+
+vi.mock("@/lib/api", () => ({
+  getCohortGarden: vi.fn(),
+}));
+
+vi.mock("@/AuthContext", () => ({
+  useAuth: () => ({ userId: "current-user" }),
+}));
+
+vi.mock("@/UserDataContext", () => ({
+  useUserData: () => ({
+    userData: { fertilizer_balance: 3 },
+    refetchUserData: vi.fn(),
+  }),
+}));
+
+vi.mock("@/application/services/fertilizerService", () => ({
+  fertilizerService: { gift: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import { getCohortGarden } from "@/lib/api";
+const mockedGetCohortGarden = vi.mocked(getCohortGarden);
+
+function member(overrides: Partial<GenmateGardenMember>): GenmateGardenMember {
+  return {
+    _id: "user-1",
+    first_name: "Alice",
+    last_name: "Smith",
+    cohort_number: 14,
+    genmate_group: "Garden Alpha",
+    reflection_dates: [],
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <AdminCohortFarmPage />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("AdminCohortFarmPage", () => {
+  beforeEach(() => {
+    mockedGetCohortGarden.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defaults to the last cohort option and shows every member across groups together", async () => {
+    const groups: CohortGardenGroup[] = [
+      {
+        group_name: "Garden Alpha",
+        members: [
+          member({ _id: "user-1", first_name: "Alice" }),
+          member({ _id: "user-2", first_name: "Bob" }),
+        ],
+      },
+      {
+        group_name: "Unaffiliated",
+        members: [member({ _id: "user-3", first_name: "Carol", genmate_group: "" })],
+      },
+    ];
+    mockedGetCohortGarden.mockResolvedValue(groups);
+
+    renderPage();
+
+    expect(await screen.findByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.getByText("Carol")).toBeInTheDocument();
+    expect(mockedGetCohortGarden).toHaveBeenCalledWith(14);
+  });
+
+  it("renders the empty state when the selected cohort has no members", async () => {
+    mockedGetCohortGarden.mockResolvedValue([]);
+
+    renderPage();
+
+    expect(await screen.findByText("No learners found for this cohort yet.")).toBeInTheDocument();
+  });
+});

--- a/src/pages/admin/AdminCohortFarmPage.tsx
+++ b/src/pages/admin/AdminCohortFarmPage.tsx
@@ -1,0 +1,185 @@
+import React, { Suspense, useMemo, useState } from "react";
+import { useQuery } from "react-query";
+import { Sprout } from "lucide-react";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { SkeletonWarm } from "@/components/loading-skeleton";
+import { getCohortGarden } from "@/lib/api";
+import { mapGenmateMembers, toFarmMembers } from "@/lib/genmate-garden";
+import { PlantTile } from "@/components/genmate-garden";
+import { useWebglSupported } from "@/hooks/use-webgl-support";
+
+const GenmateField = React.lazy(() =>
+  import("@/components/farm/GenmateField").then((mod) => ({ default: mod.GenmateField }))
+);
+
+type ViewMode = "grid" | "farm";
+const COHORT_OPTIONS = ["9", "10", "11", "12", "13", "14"];
+
+/**
+ * The admin equivalent of the learner's cohort-wide field
+ * (`CohortGenmateGardenPage.tsx`) — same flattened "everyone in one field"
+ * view, same `getCohortGarden` endpoint (already admin-bypass-enabled via
+ * `enforceCohortAccess`), just with a cohort picker instead of the learner's
+ * own `cohort_number` since an admin has no home cohort of their own.
+ *
+ * Deliberately a separate page from `/admin/garden`, which keeps its
+ * existing per-genmate-group stacked-card view unchanged — this page is
+ * "one whole cohort together," not a replacement for that one.
+ */
+export function AdminCohortFarmPage() {
+  const [cohortNumber, setCohortNumber] = useState(COHORT_OPTIONS[COHORT_OPTIONS.length - 1]);
+  const [view, setView] = useState<ViewMode>("grid");
+  const webglSupported = useWebglSupported();
+
+  const { data, isLoading, isError, refetch } = useQuery(
+    ["cohortGarden", cohortNumber],
+    () => getCohortGarden(Number(cohortNumber))
+  );
+
+  const allMembersRaw = useMemo(() => (data ?? []).flatMap((g) => g.members), [data]);
+  const members = useMemo(() => mapGenmateMembers(allMembersRaw), [allMembersRaw]);
+  const farmMembers = useMemo(() => toFarmMembers(members), [members]);
+
+  const averageStreak =
+    members.length > 0
+      ? members.reduce((sum, m) => sum + m.displayStreak, 0) / members.length
+      : 0;
+
+  const handleFarmContextLost = () => {
+    setView("grid");
+    toast.error("3D view lost — showing the grid instead");
+  };
+
+  return (
+    <div className="container mx-auto py-10 space-y-6">
+      <div className="flex flex-wrap justify-between items-center gap-4">
+        <div className="flex items-center gap-3">
+          <Sprout className="w-8 h-8 text-emerald-600 dark:text-emerald-400" />
+          <h1 className="text-3xl font-bold">Cohort Field</h1>
+        </div>
+        <Select value={cohortNumber} onValueChange={setCohortNumber}>
+          <SelectTrigger className="w-[180px] cursor-pointer" aria-label="Select cohort">
+            <SelectValue placeholder="Select Cohort" />
+          </SelectTrigger>
+          <SelectContent>
+            {COHORT_OPTIONS.map((c) => (
+              <SelectItem key={c} value={c}>
+                Cohort {c}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <p className="text-muted-foreground max-w-2xl">
+        Every learner in the selected cohort, standing together on one field — the same view
+        learners get for their own cohort, picked here by cohort number.
+      </p>
+
+      {isLoading && (
+        <Card className="w-full">
+          <CardHeader>
+            <SkeletonWarm className="h-6 w-40" />
+            <SkeletonWarm className="h-4 w-64" />
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="flex flex-col items-center gap-2">
+                  <SkeletonWarm className="h-24 w-24 rounded-xl" />
+                  <SkeletonWarm className="h-3 w-16" />
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {isError && (
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle className="text-lg">Couldn't load this cohort's field</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Something went wrong while fetching Cohort {cohortNumber}. Try again.
+            </p>
+            <Button type="button" variant="outline" className="mt-4" onClick={() => refetch()}>
+              Try again
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && members.length === 0 && (
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle className="text-lg">
+              <Sprout className="mr-2 inline-block h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+              Cohort {cohortNumber}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              No learners found for this cohort yet.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && members.length > 0 && (
+        <Card className="w-full">
+          <CardHeader className="pb-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <CardTitle className="text-base">Cohort {cohortNumber}</CardTitle>
+              <div className="flex items-center gap-3">
+                <span className="text-xs font-medium text-muted-foreground tabular-nums">
+                  {members.length} members · avg {averageStreak.toFixed(1)} days
+                </span>
+                <Tabs value={view} onValueChange={(v) => setView(v as ViewMode)}>
+                  <TabsList>
+                    <TabsTrigger value="grid">Grid</TabsTrigger>
+                    {webglSupported ? (
+                      <TabsTrigger value="farm">Farm</TabsTrigger>
+                    ) : (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span>
+                              <TabsTrigger value="farm" disabled>
+                                Farm
+                              </TabsTrigger>
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>3D view isn't supported on this device</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )}
+                  </TabsList>
+                </Tabs>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {view === "grid" ? (
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+                {members.map((member) => (
+                  <PlantTile key={member.user._id} member={member} />
+                ))}
+              </div>
+            ) : (
+              <Suspense fallback={<SkeletonWarm className="aspect-[4/3] w-full rounded-xl" />}>
+                <GenmateField members={farmMembers} onContextLost={handleFarmContextLost} />
+              </Suspense>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Builds the genmate garden's 2D plant grid into a full react-three-fiber scene: procedural 3D archetypes for every species, an FFT-style shared field with scroll/pinch zoom and 90-degree rotation, toon shading with outlines, procedural textures, rolling terrain, weather (sky/clouds), and ambient decoration (grass, fence, background trees, butterflies).

Adds a cohort-wide view (flattened across genmate groups, grid sizing that scales with headcount instead of a fixed 3x3) reachable from the learner garden page and mirrored for admins, plus a Grid/Farm toggle on the existing admin genmate garden page — all reusing the same GenmateField component and the existing cohort-garden API.