### PR TITLE
fix: size the genmate field to actual headcount, not always 3x3

### DIFF
--- a/src/lib/farm-layout.test.ts
+++ b/src/lib/farm-layout.test.ts
@@ -50,15 +50,37 @@ describe("tilePositionsForCount — ticket 10's verified fill order", () => {
   });
 });
 
-describe("gridDimensionsForCount — cohort field scaling", () => {
-  it("stays the tuned 3×3 for a genmate-group-sized count", () => {
-    expect(gridDimensionsForCount(5)).toEqual({ cols: GRID_COLS, rows: GRID_ROWS });
+describe("gridDimensionsForCount — sizes the field to the actual headcount", () => {
+  it("shrinks below 3×3 for a small group instead of leaving it in a mostly-empty field", () => {
+    expect(gridDimensionsForCount(1)).toEqual({ cols: 1, rows: 1 });
+    expect(gridDimensionsForCount(2)).toEqual({ cols: 2, rows: 1 });
+    expect(gridDimensionsForCount(3)).toEqual({ cols: 2, rows: 2 });
+    expect(gridDimensionsForCount(4)).toEqual({ cols: 2, rows: 2 });
+    expect(gridDimensionsForCount(5)).toEqual({ cols: 3, rows: 2 });
+    expect(gridDimensionsForCount(6)).toEqual({ cols: 3, rows: 2 });
+  });
+
+  it("only arrives at the tuned 3×3 once a group is actually large enough to need it", () => {
+    expect(gridDimensionsForCount(7)).toEqual({ cols: GRID_COLS, rows: GRID_ROWS });
+    expect(gridDimensionsForCount(8)).toEqual({ cols: GRID_COLS, rows: GRID_ROWS });
     expect(gridDimensionsForCount(9)).toEqual({ cols: GRID_COLS, rows: GRID_ROWS });
   });
 
   it("grows to fit a whole cohort instead of staying capped at 9", () => {
     const { cols, rows } = gridDimensionsForCount(30);
     expect(cols * rows).toBeGreaterThanOrEqual(30);
+  });
+});
+
+describe("tilePositionsForCount — small groups get compact fill, not the corners-first spread", () => {
+  it("does not scatter a 4-person group to corners once the grid is sized to fit them", () => {
+    const { cols, rows } = gridDimensionsForCount(4);
+    const positions = tilePositionsForCount(4, cols, rows);
+    const oldCornersFirst = [
+      { col: 0, row: 0 }, { col: 2, row: 0 }, { col: 0, row: 2 }, { col: 2, row: 2 },
+    ];
+    expect(positions).not.toEqual(oldCornersFirst);
+    expect(positions.length).toBe(4);
   });
 });
 

--- a/src/lib/farm-layout.ts
+++ b/src/lib/farm-layout.ts
@@ -58,16 +58,20 @@ const FILL_ORDER: TilePosition[] = [
 ];
 
 /**
- * The 3×3 field is sized for a genmate group, not a whole cohort — a cohort
- * field (COHORT_FARM_SPEC.md's "one big field" option) needs the grid to
- * actually grow with headcount instead of silently dropping anyone past the
- * 9th tile. Defaults preserve the exact tuned 3×3 behavior for every
- * existing caller (single genmate group, ≤9 members).
+ * Sizes the field to the actual headcount, always — a 2-person group gets a
+ * snug 2×1 patch, not a full 3×3 with members flung to opposite corners of a
+ * mostly-empty field. One formula for every size, genmate group or whole
+ * cohort: `ceil(sqrt(count))` columns, enough rows to fit everyone. This
+ * only produces a genuine 3×3 once a group is large enough to actually need
+ * it (7-9 members) — exactly the range `tilePositionsForCount`'s special
+ * corners-first fill order (ticket 10, tuned specifically for a full 3×3)
+ * still applies to; anything smaller gets simple compact fill instead, since
+ * a small grid has no occlusion problem to avoid in the first place.
  */
 export function gridDimensionsForCount(count: number): { cols: number; rows: number } {
-  if (count <= GRID_COLS * GRID_ROWS) return { cols: GRID_COLS, rows: GRID_ROWS };
-  const cols = Math.ceil(Math.sqrt(count));
-  const rows = Math.ceil(count / cols);
+  const n = Math.max(1, count);
+  const cols = Math.ceil(Math.sqrt(n));
+  const rows = Math.ceil(n / cols);
   return { cols, rows };
 }
 


### PR DESCRIPTION
A small genmate group (2-6 members, the common case) previously sat on a full 3x3 grid with members flung to opposite corners and empty tiles all around, reading as scattered rather than together. The field grid now sizes to fit the group (a 5-person group gets a compact 3x2 instead of 3x3 with 4 empty tiles); the corners-first anti-occlusion fill order only kicks in once a group actually fills a 3x3 (7-9 members), the range it was tuned for.