### PR TITLE
3D genmate farm: real geometry, cohort field, admin view

### DIFF
--- a/src/components/farm/SkyDome.tsx
+++ b/src/components/farm/SkyDome.tsx
@@ -2,8 +2,8 @@ import { useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import { AdditiveBlending, BackSide, BufferAttribute, Color, Group, SphereGeometry, Vector3 } from "three";
 
-const TOP_COLOR = "#7ab8dd";
-const HORIZON_COLOR = "#e8d9ae";
+const TOP_COLOR = "#3d8fd6";
+const HORIZON_COLOR = "#bfe2f5";
 const SUN_COLOR = "#ffe9a3";
 const CLOUD_COLOR = "#fdfaf3";
 const CLOUD_COUNT = 6;
@@ -44,7 +44,12 @@ export function SkyDome({ radius, sunDirection }: SkyDomeProps) {
     const horizon = new Color(HORIZON_COLOR);
     const tmp = new Color();
     for (let i = 0; i < pos.count; i++) {
-      const t = Math.max(0, Math.min(1, pos.getY(i) / radius + 0.15));
+      // Camera pitch is fairly low (~30°), so most of the dome actually in
+      // frame sits near the horizon band — biasing the blend to reach full
+      // top-blue well before the pole (`* 1.6`, was `+ 0.15`) keeps that
+      // visible portion a real sky blue instead of mostly the pale
+      // near-horizon tint.
+      const t = Math.max(0, Math.min(1, (pos.getY(i) / radius) * 1.6 + 0.2));
       tmp.copy(horizon).lerp(top, t);
       colors[i * 3] = tmp.r;
       colors[i * 3 + 1] = tmp.g;


### PR DESCRIPTION
## Summary
- Builds the 2D genmate garden into a full react-three-fiber scene: procedural 3D plant archetypes, an FFT-style shared field with scroll/pinch zoom and 90° rotation, toon shading with outlines, procedural textures, rolling terrain, sky/clouds/sun, and ambient decoration (grass, fence, background trees, butterflies).
- Adds a cohort-wide view (flattened across genmate groups, grid sizing that scales with headcount) reachable from the learner garden page and mirrored for admins, plus a Grid/Farm toggle on the existing admin genmate garden page.
- Follow-up fixes: the field now sizes tightly to actual headcount instead of always a 3×3 (small groups no longer scattered to opposite corners of a mostly-empty field), and the sky reads as a proper blue daytime sky instead of a warm-tan haze.
- Needs the companion backend PR (`baro-gofiber`, same branch name `feat/genmate-farm-3d`) for the new `GET /cohorts/:cohortNumber/garden` endpoint the cohort views call.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (only pre-existing warnings)
- [x] `npx vitest run` — 92/92 passing, including new suites for the terrain/texture/layout/decoration logic
- [ ] Manual: open the Farm view on the learner garden, cohort garden, and admin garden/cohort-farm pages — this session's browser automation can't render WebGL frames, so this needs a human check

🤖 Generated with [Claude Code](https://claude.com/claude-code)